### PR TITLE
A couple of minor docs changes as discussed on discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,17 +82,21 @@ export const MyInput = ({ name, label }: InputProps) => {
 To best take advantage of the per-form submission detection, we can create a submit button component.
 
 ```tsx
-import { useIsSubmitting } from "remix-validated-form";
+import { useFormContext, useIsSubmitting } from "remix-validated-form";
 
 export const MySubmitButton = () => {
   const isSubmitting = useIsSubmitting();
+  const { isValid } = useFormContext();
+  const disabled = isSubmitting || !isValid;
+
   return (
-    <button type="submit" disabled={isSubmitting}>
+    <button type="submit" disabled={disabled} className={disabled ? "disabled-btn" : "btn"}>
       {isSubmitting ? "Submitting..." : "Submit"}
     </button>
   );
 };
 ```
+
 
 ## Use the form!
 

--- a/README.md
+++ b/README.md
@@ -245,3 +245,8 @@ This is happening because you or the library you are using is passing the `requi
 This library doesn't take care of eliminating them and it's up to the user how they want to manage the validation errors.
 If you wan't to disable all native HTML validations you can add `noValidate` to `<ValidatedForm>`.
 We recommend this approach since the validation will still work even if JS is disabled.
+
+## How do we trigger toast messages on success?
+
+Problem: how do we trigger a toast message on success if the action redirects away from the form route? The Remix solution is to flash a message in the session and pick this up in a loader function, probably in root.tsx
+See the [Remix](https://remix.run/docs/en/v1/api/remix#sessionflashkey-value) documentation for more information.


### PR DESCRIPTION
I had the idea of writing a long how to toast section but thought it's better to link to the Remix docs as a single source of truth etc

I'll look at adding a bit more toast info to the Remix docs instead