### PR TITLE
feat: encapsulate validation behavior in `getInputProps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,18 +64,14 @@ type MyInputProps = {
 };
 
 export const MyInput = ({ name, label }: InputProps) => {
-  const { validate, clearError, defaultValue, error } = useField(name);
+  const { error, getInputProps } = useField(name);
   return (
     <div>
       <label htmlFor={name}>{label}</label>
-      <input
-        id={name}
-        name={name}
-        onBlur={validate}
-        onChange={clearError}
-        defaultValue={defaultValue}
-      />
-      {error && <span className="my-error-class">{error}</span>}
+      <input {...getInputProps({ id: name })} />
+      {error && (
+        <span className="my-error-class">{error}</span>
+      )}
     </div>
   );
 };

--- a/apps/docs/app/components/FormInput.tsx
+++ b/apps/docs/app/components/FormInput.tsx
@@ -20,8 +20,7 @@ export const FormInput: FC<
   onChange,
   ...rest
 }) => {
-  const { error, clearError, validate, defaultValue } =
-    useField(name);
+  const { error, getInputProps } = useField(name);
 
   return (
     <div className={className}>
@@ -40,22 +39,18 @@ export const FormInput: FC<
       </div>
       <div className="mt-1 relative flex rounded-md shadow-sm">
         <input
-          type="text"
-          name={name}
-          id={name}
-          className={classNames(
-            "border focus:ring-teal-500 focus:border-teal-500 focus:z-10 block w-full sm:text-sm text-black pr-10",
-            "rounded-md p-2",
-            error &&
-              "border-red-800 bg-red-50 text-red-800 placeholder-red-300 focus:outline-none focus:ring-red-500 focus:border-red-500"
-          )}
-          onChange={(event) => {
-            if (error) clearError();
-            onChange?.(event);
-          }}
-          onBlur={validate}
-          defaultValue={defaultValue}
-          {...rest}
+          {...getInputProps({
+            onChange,
+            id: name,
+            type: "text",
+            className: classNames(
+              "border focus:ring-teal-500 focus:border-teal-500 focus:z-10 block w-full sm:text-sm text-black pr-10",
+              "rounded-md p-2",
+              error &&
+                "border-red-800 bg-red-50 text-red-800 placeholder-red-300 focus:outline-none focus:ring-red-500 focus:border-red-500"
+            ),
+            ...rest,
+          })}
         />
         {error && (
           <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">

--- a/apps/docs/app/components/Layout.tsx
+++ b/apps/docs/app/components/Layout.tsx
@@ -1,6 +1,11 @@
 import { MenuAlt2Icon } from "@heroicons/react/outline";
-import React, { FC, Fragment, useState } from "react";
-import { useMatches } from "remix";
+import React, {
+  FC,
+  Fragment,
+  useEffect,
+  useState,
+} from "react";
+import { useLocation, useMatches } from "remix";
 import { Sidebar } from "../components/Sidebar";
 import { Footer } from "./Footer";
 
@@ -61,6 +66,13 @@ const navSections: Section[] = [
 ];
 
 export const Layout: FC = ({ children }) => {
+  const location = useLocation();
+  const focusedProp = location.hash.replace("#", "");
+  useEffect(() => {
+    const el = document.getElementById(focusedProp);
+    if (el) el.scrollIntoView();
+  }, [focusedProp]);
+
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const matches = useMatches();

--- a/apps/docs/app/components/PropHeader.tsx
+++ b/apps/docs/app/components/PropHeader.tsx
@@ -1,4 +1,6 @@
+import { LinkIcon } from "@heroicons/react/outline";
 import classNames from "classnames";
+import { useLocation } from "remix";
 
 type PropHeaderProps = {
   variant?: "h1" | "h3";
@@ -23,14 +25,27 @@ export const PropHeader = ({
   optional,
   variant: Variant = "h3",
 }: PropHeaderProps) => {
+  const location = useLocation();
+  const focusedProp = location.hash.replace("#", "");
   return (
     <Variant>
       <div className={variantHeaderColors[Variant]}>
-        {prop}
+        <a
+          id={prop}
+          href={`#${prop}`}
+          className={classNames(
+            "-ml-6 flex items-center group",
+            focusedProp !== prop && "no-underline"
+          )}
+        >
+          <LinkIcon className="h-4 w-4 mr-2 invisible group-hover:visible" />
+          {prop}
+        </a>
       </div>
       <div
         className={classNames(
           "text-zinc-500",
+          "whitespace-pre-wrap",
           variantTypeSizes[Variant]
         )}
       >

--- a/apps/docs/app/routes/integrate-your-components.mdx
+++ b/apps/docs/app/routes/integrate-your-components.mdx
@@ -21,6 +21,10 @@ so these features only work if you use it in a `ValidatedForm`.
 However, it is still safe to use your input outside of a `ValidatedForm`,
 it just won't be able to take advantage of the features.
 
+If this example doesn't validate at the right times for your use-case,
+or you don't have a plain input,
+check out the [useField](/reference/use-field) documentation to see what other helpers and options are available.
+
 ```tsx
 import { useField } from "remix-validated-form";
 
@@ -30,18 +34,11 @@ type MyInputProps = {
 };
 
 export const MyInput = ({ name, label }: InputProps) => {
-  const { validate, clearError, defaultValue, error } =
-    useField(name);
+  const { error, getInputProps } = useField(name);
   return (
     <div>
       <label htmlFor={name}>{label}</label>
-      <input
-        id={name}
-        name={name}
-        onBlur={validate}
-        onChange={clearError}
-        defaultValue={defaultValue}
-      />
+      <input {...getInputProps({ id: name })} />
       {error && (
         <span className="my-error-class">{error}</span>
       )}

--- a/apps/docs/app/routes/integrate-your-components.mdx
+++ b/apps/docs/app/routes/integrate-your-components.mdx
@@ -21,7 +21,7 @@ so these features only work if you use it in a `ValidatedForm`.
 However, it is still safe to use your input outside of a `ValidatedForm`,
 it just won't be able to take advantage of the features.
 
-If this example doesn't validate at the right times for your use-case,
+If this example doesn't validate at the right times for your use-case
 or you don't have a plain input,
 check out the [useField](/reference/use-field) documentation to see what other helpers and options are available.
 

--- a/apps/docs/app/routes/reference/use-field.mdx
+++ b/apps/docs/app/routes/reference/use-field.mdx
@@ -28,12 +28,12 @@ The validation error message if there is one.
 <PropHeader
   prop="getInputProps"
   type={
-    '(props: JSX.IntrinsicElements["input"]) => JSX.IntrinsicElements["input"]'
+    '(props?: JSX.IntrinsicElements["input"]) => JSX.IntrinsicElements["input"]'
   }
 />
 
 A prop-getter used to get the props for the input.
-This will automatically set up the validation behavior based on the [`validationBehavior`](#validationBehavior) prop.
+This will automatically set up the validation behavior based on the [`validationBehavior`](#validationBehavior) option.
 
 <PropHeader prop="defaultValue" type="any" />
 
@@ -50,6 +50,7 @@ Validates the form field and populates the `error` prop if there is an error.
 <PropHeader prop="touched" type="boolean" />
 
 Whether or not the field has been touched.
+If you're using `getInputProps`, a field will become touched on blur.
 
 <PropHeader
   prop="setTouched"
@@ -71,23 +72,23 @@ Sets the `touched` state of the field to whatever you pass in.
 />
 
 Allows you to configure when the field should validate.
-The keys are states the field/form could be in,
-and the values are when you want to validate while in that state.
+The keys (`initial`, `whenTouched`, `whenSubmitted`) are states the field/form could be in,
+and the values (`onChange`, `onBlur`, `onSubmit`) are when you want to validate while in that state.
 
-**Note** This behavior only applies when you are using `getInputProps`.
-If you're managing the validation manually using `validate`, `clearError`, `setTouched`, etc,
+**Note:** This behavior only applies when you are using `getInputProps`.
+If you're managing the validation manually (using `validate`, `clearError`, `setTouched`, etc),
 this will have no effect.
 
-#### Initial, whenTouched, whenSubmitted
+#### Field/form states
 
 - `initial`
   - The field has not been touched and the form has not been submitted.
 - `whenTouched`
-  - The user touched the field. A field becomes touched on blur, or when you call `setTouched`.
+  - The user touched the field. A field becomes touched on blur, or when you call `setTouched(true)`.
 - `whenSubmitted`
-  - The user attempted to submit the form..
+  - The user attempted to submit the form.
 
-#### onChange, onBlur, onSubmit
+#### When to validate
 
 - `onChange`
   - Validates every time the `onChange` event of the input fires.
@@ -97,7 +98,7 @@ this will have no effect.
 - `onSubmit`
   - The field does not validate itself at all and only validates when the form is submitted.
 
-For all three options, the form will be validated on submit.
+No matter which option you choose, the form will always be validated again on submit.
 
 #### Default configuration
 

--- a/apps/docs/app/routes/reference/use-field.mdx
+++ b/apps/docs/app/routes/reference/use-field.mdx
@@ -27,9 +27,7 @@ The validation error message if there is one.
 
 <PropHeader
   prop="getInputProps"
-  type={
-    '(props?: JSX.IntrinsicElements["input"]) => JSX.IntrinsicElements["input"]'
-  }
+  type={`<T extends {}>(props?: T) => T`}
 />
 
 A prop-getter used to get the props for the input.

--- a/apps/docs/app/routes/reference/use-field.mdx
+++ b/apps/docs/app/routes/reference/use-field.mdx
@@ -3,6 +3,7 @@ meta:
   title: useField (Remix Validated Form)
 ---
 
+import outdent from "outdent";
 import { PropHeader } from "~/components/PropHeader";
 
 <PropHeader
@@ -24,6 +25,16 @@ and the helpers will be no-ops.
 
 The validation error message if there is one.
 
+<PropHeader
+  prop="getInputProps"
+  type={
+    '(props: JSX.IntrinsicElements["input"]) => JSX.IntrinsicElements["input"]'
+  }
+/>
+
+A prop-getter used to get the props for the input.
+This will automatically set up the validation behavior based on the [`validationBehavior`](#validationBehavior) prop.
+
 <PropHeader prop="defaultValue" type="any" />
 
 The default value of the field, if there is one.
@@ -36,7 +47,70 @@ Clears the error message.
 
 Validates the form field and populates the `error` prop if there is an error.
 
+<PropHeader prop="touched" type="boolean" />
+
+Whether or not the field has been touched.
+
+<PropHeader
+  prop="setTouched"
+  type="(touched: boolean) => void"
+/>
+
+Sets the `touched` state of the field to whatever you pass in.
+
 ## UseFieldOptions
+
+<PropHeader
+  prop="validationBehavior"
+  type={outdent`
+  {
+    initial?: "onChange" | "onBlur" | "onSubmit";
+    whenTouched?: "onChange" | "onBlur" | "onSubmit";
+    whenSubmitted?: "onChange" | "onBlur" | "onSubmit";
+  }`}
+/>
+
+Allows you to configure when the field should validate.
+The keys are states the field/form could be in,
+and the values are when you want to validate while in that state.
+
+**Note** This behavior only applies when you are using `getInputProps`.
+If you're managing the validation manually using `validate`, `clearError`, `setTouched`, etc,
+this will have no effect.
+
+#### Initial, whenTouched, whenSubmitted
+
+- `initial`
+  - The field has not been touched and the form has not been submitted.
+- `whenTouched`
+  - The user touched the field. A field becomes touched on blur, or when you call `setTouched`.
+- `whenSubmitted`
+  - The user attempted to submit the form..
+
+#### onChange, onBlur, onSubmit
+
+- `onChange`
+  - Validates every time the `onChange` event of the input fires.
+- `onBlur`
+  - Validates every time the `onBlur` event of the input fires.
+  - Clears the error message when the user starts typing in that field again.
+- `onSubmit`
+  - The field does not validate itself at all and only validates when the form is submitted.
+
+For all three options, the form will be validated on submit.
+
+#### Default configuration
+
+By default the field will validate on blur,
+then validate on every change after the field has been touched our submitted.
+
+```
+{
+  initial: "onBlur",
+  whenTouched: "onChange",
+  whenSubmitted: "onChange",
+}
+```
 
 <PropHeader
   prop="handleReceiveFocus"

--- a/apps/docs/app/routes/reference/use-form-context.mdx
+++ b/apps/docs/app/routes/reference/use-form-context.mdx
@@ -69,3 +69,20 @@ This resets when the form resets.
 The default values of the `ValidatedForm` component.
 In cases where the user has javascript disabled,
 this can sometimes be something other than what is passed into the `ValidatedForm` directly.
+
+<PropHeader
+  prop="touchedFields"
+  type="Record<string, boolean>"
+/>
+
+Contains all the touched fields.
+The keys of the object are the field names and values are whether or not the field has been touched.
+If a field has not been touched at all, the value will be `undefined`.
+If you set touched to `false` manually, then the value will be `false`.
+
+<PropHeader
+  prop="setFieldTouched"
+  type="(fieldName: string, touched: boolean) => void"
+/>
+
+Manually set the `touched` state of the specified field.

--- a/apps/docs/app/routes/reference/use-form-context.mdx
+++ b/apps/docs/app/routes/reference/use-form-context.mdx
@@ -53,7 +53,13 @@ If no `action` prop is passed, this will be `undefined`.
 
 <PropHeader prop="isSubmitting" type="boolean" />
 
-Whether or not the form is submitting.
+Whether or not the form is currently submitting.
+
+<PropHeader prop="hasBeenSubmitted" type="boolean" />
+
+Whether or not a submit has been attempted.
+This will be `true` after the first submit attempt, even if the form is invalid.
+This resets when the form resets.
 
 <PropHeader
   prop="defaultValues"

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -27,6 +27,7 @@
     "framer-motion": "^5.5.5",
     "highlight.js": "^11.3.1",
     "lodash": "^4.17.21",
+    "outdent": "^0.8.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "rehype-highlight": "^5.0.1",

--- a/apps/sample-app/app/components/FormInput.tsx
+++ b/apps/sample-app/app/components/FormInput.tsx
@@ -19,19 +19,17 @@ export const FormInput = ({
   isRequired,
   ...rest
 }: FormInputProps & InputProps) => {
-  const { validate, clearError, defaultValue, error } = useField(name);
+  const { getInputProps, error } = useField(name);
 
   return (
     <>
       <FormControl isInvalid={!!error} isRequired={isRequired}>
         <FormLabel htmlFor={name}>{label}</FormLabel>
         <Input
-          id={name}
-          name={name}
-          onBlur={validate}
-          onChange={clearError}
-          defaultValue={defaultValue}
-          {...rest}
+          {...getInputProps({
+            id: name,
+            ...rest,
+          })}
         />
         {error && <FormErrorMessage>{error}</FormErrorMessage>}
       </FormControl>

--- a/apps/sample-app/app/components/FormSelect.tsx
+++ b/apps/sample-app/app/components/FormSelect.tsx
@@ -19,17 +19,15 @@ export const FormSelect = ({
   isRequired,
   ...rest
 }: FormSelectProps & SelectProps) => {
-  const { validate, clearError, defaultValue, error } = useField(name);
+  const { getInputProps, error } = useField(name);
   return (
     <FormControl isInvalid={!!error} isRequired={isRequired}>
       <FormLabel htmlFor={name}>{label}</FormLabel>
       <Select
-        id={name}
-        name={name}
-        onBlur={validate}
-        onChange={clearError}
-        defaultValue={defaultValue}
-        {...rest}
+        {...getInputProps({
+          id: name,
+          ...rest,
+        })}
       />
       {error && <FormErrorMessage>{error}</FormErrorMessage>}
     </FormControl>

--- a/apps/test-app/app/components/Input.tsx
+++ b/apps/test-app/app/components/Input.tsx
@@ -4,26 +4,15 @@ import { useField } from "remix-validated-form";
 type InputProps = {
   name: string;
   label: string;
-  validateOnBlur?: boolean;
 };
 
 export const Input = forwardRef(
-  (
-    { name, label, validateOnBlur }: InputProps,
-    ref: React.ForwardedRef<HTMLInputElement>
-  ) => {
-    const { validate, clearError, defaultValue, error } = useField(name);
+  ({ name, label }: InputProps, ref: React.ForwardedRef<HTMLInputElement>) => {
+    const { getInputProps, error } = useField(name);
     return (
       <div>
         <label htmlFor={name}>{label}</label>
-        <input
-          id={name}
-          name={name}
-          onBlur={validateOnBlur ? validate : undefined}
-          onChange={clearError}
-          defaultValue={defaultValue}
-          ref={ref}
-        />
+        <input {...getInputProps({ ref, id: name })} />
         {error && <span style={{ color: "red" }}>{error}</span>}
       </div>
     );

--- a/apps/test-app/app/components/InputWithTouched.tsx
+++ b/apps/test-app/app/components/InputWithTouched.tsx
@@ -1,0 +1,35 @@
+import React, { forwardRef } from "react";
+import { useField } from "remix-validated-form";
+
+type InputProps = {
+  name: string;
+  label: string;
+};
+
+export const InputWithTouched = forwardRef(
+  ({ name, label }: InputProps, ref: React.ForwardedRef<HTMLInputElement>) => {
+    const { validate, clearError, defaultValue, error, touched, setTouched } =
+      useField(name);
+    return (
+      <div>
+        <label htmlFor={name}>{label}</label>
+        <input
+          id={name}
+          name={name}
+          onBlur={() => {
+            setTouched(true);
+            validate();
+          }}
+          onChange={() => {
+            if (touched) validate();
+            else clearError();
+          }}
+          defaultValue={defaultValue}
+          ref={ref}
+        />
+        {touched && <span>{name} touched</span>}
+        {error && <span style={{ color: "red" }}>{error}</span>}
+      </div>
+    );
+  }
+);

--- a/apps/test-app/app/routes/submission.aftersubmit.tsx
+++ b/apps/test-app/app/routes/submission.aftersubmit.tsx
@@ -6,7 +6,10 @@ import * as yup from "yup";
 import { Input } from "~/components/Input";
 import { SubmitButton } from "~/components/SubmitButton";
 
-const schema = yup.object({});
+const schema = yup.object({
+  testinput: yup.string(),
+  anotherinput: yup.string(),
+});
 const validator = withYup(schema);
 
 export const action: ActionFunction = async ({ request }) => {

--- a/apps/test-app/app/routes/submission.hasbeensubmitted.tsx
+++ b/apps/test-app/app/routes/submission.hasbeensubmitted.tsx
@@ -1,0 +1,27 @@
+import { withYup } from "@remix-validated-form/with-yup";
+import { useFormContext, ValidatedForm } from "remix-validated-form";
+import * as yup from "yup";
+import { Input } from "~/components/Input";
+import { SubmitButton } from "~/components/SubmitButton";
+
+const schema = yup.object({
+  firstName: yup.string().label("First Name").required(),
+});
+
+const validator = withYup(schema);
+
+const IsSubmitted = () => {
+  const { hasBeenSubmitted } = useFormContext();
+  return hasBeenSubmitted ? <h1>Submitted!</h1> : null;
+};
+
+export default function FrontendValidation() {
+  return (
+    <ValidatedForm validator={validator}>
+      <Input name="firstName" label="First Name" validateOnBlur />
+      <SubmitButton />
+      <IsSubmitted />
+      <button type="reset">Reset</button>
+    </ValidatedForm>
+  );
+}

--- a/apps/test-app/app/routes/touched-state.tsx
+++ b/apps/test-app/app/routes/touched-state.tsx
@@ -1,0 +1,21 @@
+import { withYup } from "@remix-validated-form/with-yup";
+import { ValidatedForm } from "remix-validated-form";
+import * as yup from "yup";
+import { InputWithTouched } from "~/components/InputWithTouched";
+
+const schema = yup.object({
+  firstName: yup.string(),
+  lastName: yup.string(),
+});
+
+const validator = withYup(schema);
+
+export default function FrontendValidation() {
+  return (
+    <ValidatedForm validator={validator} method="post">
+      <InputWithTouched name="firstName" label="First Name" />
+      <InputWithTouched name="lastName" label="Last Name" />
+      <button type="reset">Reset</button>
+    </ValidatedForm>
+  );
+}

--- a/apps/test-app/app/routes/validation-fetcher.tsx
+++ b/apps/test-app/app/routes/validation-fetcher.tsx
@@ -26,9 +26,9 @@ export default function FrontendValidation() {
   return (
     <ValidatedForm validator={validator} method="post" fetcher={fetcher}>
       {fetcher.data?.message && <h1>{fetcher.data.message}</h1>}
-      <Input name="firstName" label="First Name" validateOnBlur />
-      <Input name="lastName" label="Last Name" validateOnBlur />
-      <Input name="email" label="Email" validateOnBlur />
+      <Input name="firstName" label="First Name" />
+      <Input name="lastName" label="Last Name" />
+      <Input name="email" label="Email" />
       <SubmitButton />
     </ValidatedForm>
   );

--- a/apps/test-app/app/routes/validation-nofocus.tsx
+++ b/apps/test-app/app/routes/validation-nofocus.tsx
@@ -25,10 +25,10 @@ export default function FrontendValidation() {
   return (
     <ValidatedForm validator={validator} method="post" disableFocusOnError>
       {actionData && <h1>{actionData.message}</h1>}
-      <Input name="firstName" label="First Name" validateOnBlur />
-      <Input name="lastName" label="Last Name" validateOnBlur />
-      <Input name="email" label="Email" validateOnBlur />
-      <Input name="contacts[0].name" label="Name of a contact" validateOnBlur />
+      <Input name="firstName" label="First Name" />
+      <Input name="lastName" label="Last Name" />
+      <Input name="email" label="Email" />
+      <Input name="contacts[0].name" label="Name of a contact" />
       <SubmitButton />
     </ValidatedForm>
   );

--- a/apps/test-app/app/routes/validation.tsx
+++ b/apps/test-app/app/routes/validation.tsx
@@ -33,10 +33,10 @@ export default function FrontendValidation() {
   return (
     <ValidatedForm validator={validator} method="post">
       {actionData && <h1>{actionData.message}</h1>}
-      <Input name="firstName" label="First Name" validateOnBlur />
-      <Input name="lastName" label="Last Name" validateOnBlur />
-      <Input name="email" label="Email" validateOnBlur />
-      <Input name="contacts[0].name" label="Name of a contact" validateOnBlur />
+      <Input name="firstName" label="First Name" />
+      <Input name="lastName" label="Last Name" />
+      <Input name="email" label="Email" />
+      <Input name="contacts[0].name" label="Name of a contact" />
       <SubmitButton />
       <button type="reset">Reset</button>
     </ValidatedForm>

--- a/apps/test-app/cypress/integration/submission.ts
+++ b/apps/test-app/cypress/integration/submission.ts
@@ -74,4 +74,16 @@ describe("Validation", () => {
     cy.findByText("Submit").click();
     cy.findByLabelText("Test input").should("have.value", "noreset");
   });
+
+  it("should track whether or not submission has been attempted", () => {
+    cy.visit("/submission/hasbeensubmitted");
+    cy.findByText("Submitted!").should("not.exist");
+
+    cy.findByText("Submit").click();
+    cy.findByText("Submitted!").should("exist");
+    cy.findByText("First Name is a required field").should("exist");
+
+    cy.findByText("Reset").click();
+    cy.findByText("Submitted!").should("not.exist");
+  });
 });

--- a/apps/test-app/cypress/integration/touched-state.ts
+++ b/apps/test-app/cypress/integration/touched-state.ts
@@ -1,0 +1,21 @@
+describe("Touched state", () => {
+  it("should track touched state and reset when the form is reset", () => {
+    cy.visit("/touched-state");
+
+    cy.findByText("firstName touched").should("not.exist");
+    cy.findByText("lastName touched").should("not.exist");
+
+    cy.findByLabelText("First Name").focus().blur();
+    cy.findByText("firstName touched").should("exist");
+    cy.findByText("lastName touched").should("not.exist");
+
+    cy.findByLabelText("Last Name").focus().blur();
+    cy.findByText("firstName touched").should("exist");
+    cy.findByText("lastName touched").should("exist");
+
+    cy.findByText("Reset").click();
+
+    cy.findByText("firstName touched").should("not.exist");
+    cy.findByText("lastName touched").should("not.exist");
+  });
+});

--- a/apps/test-app/cypress/integration/validation-with-fetchers.ts
+++ b/apps/test-app/cypress/integration/validation-with-fetchers.ts
@@ -15,10 +15,9 @@ describe("Validation with fetchers", () => {
     cy.findByLabelText("Email").focus().blur();
     cy.findByText("Email is a required field").should("exist");
     cy.findByLabelText("Email").type("not an email");
-    cy.findByLabelText("Email").blur();
     cy.findByText("Email must be a valid email").should("exist");
 
-    cy.findByLabelText("Email").clear().type("an.email@example.com").blur();
+    cy.findByLabelText("Email").clear().type("an.email@example.com");
     cy.findByText("Email must be a valid email").should("not.exist");
 
     cy.findByText("Email is a required field").should("not.exist");
@@ -44,7 +43,7 @@ describe("Validation with fetchers", () => {
     cy.findByLabelText("Last Name").type("Doe");
     cy.findByText("Last Name is a required field").should("not.exist");
 
-    cy.findByLabelText("Email").type("an.email@example.com").blur();
+    cy.findByLabelText("Email").type("an.email@example.com");
     cy.findByText("Email is a required field").should("not.exist");
 
     cy.findByText("Submit").click();

--- a/apps/test-app/cypress/integration/validation.ts
+++ b/apps/test-app/cypress/integration/validation.ts
@@ -15,7 +15,6 @@ describe("Validation", () => {
     cy.findByLabelText("Email").focus().blur();
     cy.findByText("Email is a required field").should("exist");
     cy.findByLabelText("Email").type("not an email");
-    cy.findByLabelText("Email").blur();
     cy.findByText("Email must be a valid email").should("exist");
 
     cy.findByLabelText("Name of a contact").focus().blur();
@@ -23,7 +22,7 @@ describe("Validation", () => {
     cy.findByLabelText("Name of a contact").type("Someone else");
     cy.findByText("Name of a contact is a required field").should("not.exist");
 
-    cy.findByLabelText("Email").clear().type("an.email@example.com").blur();
+    cy.findByLabelText("Email").clear().type("an.email@example.com");
     cy.findByText("Email must be a valid email").should("not.exist");
 
     cy.findByText("Email is a required field").should("not.exist");
@@ -58,7 +57,7 @@ describe("Validation", () => {
     cy.findByText("Submit").click();
     cy.findByLabelText("Email").should("be.focused");
 
-    cy.findByLabelText("Email").type("an.email@example.com").blur();
+    cy.findByLabelText("Email").type("an.email@example.com");
     cy.findByText("Email is a required field").should("not.exist");
 
     cy.findByText("Submit").click();
@@ -104,7 +103,7 @@ describe("Validation", () => {
 
     cy.findByLabelText("First Name").type("John");
     cy.findByLabelText("Last Name").type("Doe");
-    cy.findByLabelText("Email").type("an.email@example.com").blur();
+    cy.findByLabelText("Email").type("an.email@example.com");
     cy.findByLabelText("Name of a contact").type("Someone else");
 
     cy.findByText("Submit").click();
@@ -126,7 +125,7 @@ describe("Validation", () => {
     cy.findByLabelText("First Name").should("have.value", "John");
     cy.findByLabelText("Last Name").should("have.value", "Doe");
 
-    cy.findByLabelText("Email").type("an.email@example.com").blur();
+    cy.findByLabelText("Email").type("an.email@example.com");
     cy.findByLabelText("Name of a contact").type("Someone else");
 
     cy.findByText("Submit").click();

--- a/packages/remix-validated-form/src/ValidatedForm.tsx
+++ b/packages/remix-validated-form/src/ValidatedForm.tsx
@@ -234,6 +234,8 @@ export function ValidatedForm<DataType>({
             ...prev,
             [fieldName]: error,
           }));
+        } else {
+          setFieldErrors((prev) => omit(prev, fieldName));
         }
       },
       registerReceiveFocus: (fieldName, handler) => {

--- a/packages/remix-validated-form/src/ValidatedForm.tsx
+++ b/packages/remix-validated-form/src/ValidatedForm.tsx
@@ -198,6 +198,7 @@ export function ValidatedForm<DataType>({
   const isSubmitting = useIsSubmitting(action, subaction, fetcher);
   const defaultsToUse = useDefaultValues(fieldErrorsFromBackend, defaultValues);
   const [touchedFields, setTouchedFields] = useState<TouchedFields>({});
+  const [hasBeenSubmitted, setHasBeenSubmitted] = useState(false);
   const formRef = useRef<HTMLFormElement>(null);
   useSubmitComplete(isSubmitting, () => {
     if (!fieldErrorsFromBackend && resetAfterSubmit) {
@@ -241,6 +242,7 @@ export function ValidatedForm<DataType>({
           customFocusHandlers().remove(fieldName, handler);
         };
       },
+      hasBeenSubmitted,
     }),
     [
       fieldErrors,
@@ -248,6 +250,7 @@ export function ValidatedForm<DataType>({
       defaultsToUse,
       isSubmitting,
       touchedFields,
+      hasBeenSubmitted,
       setFieldErrors,
       validator,
       customFocusHandlers,
@@ -262,6 +265,7 @@ export function ValidatedForm<DataType>({
       {...rest}
       action={action}
       onSubmit={(event) => {
+        setHasBeenSubmitted(true);
         const result = validator.validate(getDataFromForm(event.currentTarget));
         if (result.error) {
           event.preventDefault();
@@ -282,6 +286,7 @@ export function ValidatedForm<DataType>({
         if (event.defaultPrevented) return;
         setFieldErrors({});
         setTouchedFields({});
+        setHasBeenSubmitted(false);
       }}
     >
       <FormContext.Provider value={contextValue}>

--- a/packages/remix-validated-form/src/ValidatedForm.tsx
+++ b/packages/remix-validated-form/src/ValidatedForm.tsx
@@ -24,6 +24,7 @@ import {
   FieldErrors,
   Validator,
   FieldErrorsWithData,
+  TouchedFields,
 } from "./validation/types";
 
 export type FormProps<DataType> = {
@@ -196,6 +197,7 @@ export function ValidatedForm<DataType>({
   const [fieldErrors, setFieldErrors] = useFieldErrors(fieldErrorsFromBackend);
   const isSubmitting = useIsSubmitting(action, subaction, fetcher);
   const defaultsToUse = useDefaultValues(fieldErrorsFromBackend, defaultValues);
+  const [touchedFields, setTouchedFields] = useState<TouchedFields>({});
   const formRef = useRef<HTMLFormElement>(null);
   useSubmitComplete(isSubmitting, () => {
     if (!fieldErrorsFromBackend && resetAfterSubmit) {
@@ -211,6 +213,12 @@ export function ValidatedForm<DataType>({
       defaultValues: defaultsToUse,
       isSubmitting: isSubmitting ?? false,
       isValid: Object.keys(fieldErrors).length === 0,
+      touchedFields,
+      setFieldTouched: (fieldName: string, touched: boolean) =>
+        setTouchedFields((prev) => ({
+          ...prev,
+          [fieldName]: touched,
+        })),
       clearError: (fieldName) => {
         setFieldErrors((prev) => omit(prev, fieldName));
       },
@@ -239,6 +247,7 @@ export function ValidatedForm<DataType>({
       action,
       defaultsToUse,
       isSubmitting,
+      touchedFields,
       setFieldErrors,
       validator,
       customFocusHandlers,
@@ -272,6 +281,7 @@ export function ValidatedForm<DataType>({
         onReset?.(event);
         if (event.defaultPrevented) return;
         setFieldErrors({});
+        setTouchedFields({});
       }}
     >
       <FormContext.Provider value={contextValue}>

--- a/packages/remix-validated-form/src/hooks.ts
+++ b/packages/remix-validated-form/src/hooks.ts
@@ -20,6 +20,14 @@ export type FieldProps = {
    * The default value of the field, if there is one.
    */
   defaultValue?: any;
+  /**
+   * Whether or not the field has been touched.
+   */
+  touched: boolean;
+  /**
+   * Helper to set the touched state of the field.
+   */
+  setTouched: (touched: boolean) => void;
 };
 
 /**
@@ -42,8 +50,11 @@ export const useField = (
     validateField,
     defaultValues,
     registerReceiveFocus,
+    touchedFields,
+    setFieldTouched,
   } = useContext(FormContext);
 
+  const isTouched = touchedFields[name];
   const { handleReceiveFocus } = options ?? {};
 
   useEffect(() => {
@@ -61,8 +72,18 @@ export const useField = (
       defaultValue: defaultValues
         ? get(defaultValues, toPath(name), undefined)
         : undefined,
+      touched: isTouched,
+      setTouched: (touched: boolean) => setFieldTouched(name, touched),
     }),
-    [clearError, defaultValues, fieldErrors, name, validateField]
+    [
+      fieldErrors,
+      name,
+      defaultValues,
+      isTouched,
+      setFieldTouched,
+      clearError,
+      validateField,
+    ]
   );
 
   return field;

--- a/packages/remix-validated-form/src/hooks.ts
+++ b/packages/remix-validated-form/src/hooks.ts
@@ -68,7 +68,7 @@ export const useField = (
     hasBeenSubmitted,
   } = useContext(FormContext);
 
-  const isTouched = touchedFields[name];
+  const isTouched = !!touchedFields[name];
   const { handleReceiveFocus } = options ?? {};
 
   useEffect(() => {

--- a/packages/remix-validated-form/src/internal/formContext.ts
+++ b/packages/remix-validated-form/src/internal/formContext.ts
@@ -1,5 +1,5 @@
 import { createContext } from "react";
-import { FieldErrors } from "../validation/types";
+import { FieldErrors, TouchedFields } from "../validation/types";
 
 export type FormContextValue = {
   /**
@@ -36,6 +36,14 @@ export type FormContextValue = {
    * the field needs to receive focus due to a validation error.
    */
   registerReceiveFocus: (fieldName: string, handler: () => void) => () => void;
+  /**
+   * Any fields that have been touched by the user.
+   */
+  touchedFields: TouchedFields;
+  /**
+   * Change the touched state of the specified field.
+   */
+  setFieldTouched: (fieldName: string, touched: boolean) => void;
 };
 
 export const FormContext = createContext<FormContextValue>({
@@ -45,4 +53,6 @@ export const FormContext = createContext<FormContextValue>({
   isSubmitting: false,
   isValid: true,
   registerReceiveFocus: () => () => {},
+  touchedFields: {},
+  setFieldTouched: () => {},
 });

--- a/packages/remix-validated-form/src/internal/formContext.ts
+++ b/packages/remix-validated-form/src/internal/formContext.ts
@@ -23,6 +23,12 @@ export type FormContextValue = {
    */
   isSubmitting: boolean;
   /**
+   * Whether or not a submission has been attempted.
+   * This is true once the form has been submitted, even if there were validation errors.
+   * Resets to false when the form is reset.
+   */
+  hasBeenSubmitted: boolean;
+  /**
    * Whether or not the form is valid.
    * This is a shortcut for `Object.keys(fieldErrors).length === 0`.
    */
@@ -51,6 +57,7 @@ export const FormContext = createContext<FormContextValue>({
   clearError: () => {},
   validateField: () => {},
   isSubmitting: false,
+  hasBeenSubmitted: false,
   isValid: true,
   registerReceiveFocus: () => () => {},
   touchedFields: {},

--- a/packages/remix-validated-form/src/internal/getInputProps.ts
+++ b/packages/remix-validated-form/src/internal/getInputProps.ts
@@ -17,9 +17,21 @@ export type CreateGetInputPropsOptions = {
   name: string;
 };
 
-export type GetInputProps = (
-  props?: JSX.IntrinsicElements["input"]
-) => JSX.IntrinsicElements["input"];
+export type MinimalInputProps = {
+  onChange?: (...args: any[]) => void;
+  onBlur?: (...args: any[]) => void;
+};
+
+export type MinimalResult = {
+  name: string;
+  onChange: (...args: any[]) => void;
+  onBlur: (...args: any[]) => void;
+  defaultValue?: any;
+};
+
+export type GetInputProps = <T extends {}>(
+  props?: T & MinimalInputProps
+) => T & MinimalResult;
 
 const defaultValidationBehavior: ValidationBehaviorOptions = {
   initial: "onBlur",
@@ -42,23 +54,23 @@ export const createGetInputProps = ({
     ...validationBehavior,
   };
 
-  return ({ onChange, onBlur, onFocus, ...rest } = {}) => {
+  return (props = {} as any) => {
     const behavior = hasBeenSubmitted
       ? validationBehaviors.whenSubmitted
       : touched
       ? validationBehaviors.whenTouched
       : validationBehaviors.initial;
     return {
-      ...rest,
+      ...props,
       onChange: (...args) => {
         if (behavior === "onChange") validate();
         else clearError();
-        onChange?.(...args);
+        return props?.onChange?.(...args);
       },
       onBlur: (...args) => {
         if (behavior === "onBlur") validate();
         setTouched(true);
-        onBlur?.(...args);
+        return props?.onBlur?.(...args);
       },
       defaultValue,
       name,

--- a/packages/remix-validated-form/src/internal/getInputProps.ts
+++ b/packages/remix-validated-form/src/internal/getInputProps.ts
@@ -18,7 +18,7 @@ export type CreateGetInputPropsOptions = {
 };
 
 export type GetInputProps = (
-  props: JSX.IntrinsicElements["input"]
+  props?: JSX.IntrinsicElements["input"]
 ) => JSX.IntrinsicElements["input"];
 
 const defaultValidationBehavior: ValidationBehaviorOptions = {
@@ -42,7 +42,7 @@ export const createGetInputProps = ({
     ...validationBehavior,
   };
 
-  return ({ onChange, onBlur, onFocus, ...rest }) => {
+  return ({ onChange, onBlur, onFocus, ...rest } = {}) => {
     const behavior = hasBeenSubmitted
       ? validationBehaviors.whenSubmitted
       : touched

--- a/packages/remix-validated-form/src/internal/getInputProps.ts
+++ b/packages/remix-validated-form/src/internal/getInputProps.ts
@@ -1,0 +1,67 @@
+export type ValidationBehavior = "onBlur" | "onChange" | "onSubmit";
+
+export type ValidationBehaviorOptions = {
+  initial: ValidationBehavior;
+  whenTouched: ValidationBehavior;
+  whenSubmitted: ValidationBehavior;
+};
+
+export type CreateGetInputPropsOptions = {
+  clearError: () => void;
+  validate: () => void;
+  defaultValue?: any;
+  touched: boolean;
+  setTouched: (touched: boolean) => void;
+  hasBeenSubmitted: boolean;
+  validationBehavior?: Partial<ValidationBehaviorOptions>;
+  name: string;
+};
+
+export type GetInputProps = (
+  props: JSX.IntrinsicElements["input"]
+) => JSX.IntrinsicElements["input"];
+
+const defaultValidationBehavior: ValidationBehaviorOptions = {
+  initial: "onBlur",
+  whenTouched: "onChange",
+  whenSubmitted: "onChange",
+};
+
+export const createGetInputProps = ({
+  clearError,
+  validate,
+  defaultValue,
+  touched,
+  setTouched,
+  hasBeenSubmitted,
+  validationBehavior,
+  name,
+}: CreateGetInputPropsOptions): GetInputProps => {
+  const validationBehaviors = {
+    ...defaultValidationBehavior,
+    ...validationBehavior,
+  };
+
+  return ({ onChange, onBlur, onFocus, ...rest }) => {
+    const behavior = hasBeenSubmitted
+      ? validationBehaviors.whenSubmitted
+      : touched
+      ? validationBehaviors.whenTouched
+      : validationBehaviors.initial;
+    return {
+      ...rest,
+      onChange: (...args) => {
+        if (behavior === "onChange") validate();
+        else clearError();
+        onChange?.(...args);
+      },
+      onBlur: (...args) => {
+        if (behavior === "onBlur") validate();
+        setTouched(true);
+        onBlur?.(...args);
+      },
+      defaultValue,
+      name,
+    };
+  };
+};

--- a/packages/remix-validated-form/src/validation/types.ts
+++ b/packages/remix-validated-form/src/validation/types.ts
@@ -1,5 +1,7 @@
 export type FieldErrors = Record<string, string>;
 
+export type TouchedFields = Record<string, boolean>;
+
 export type FieldErrorsWithData = FieldErrors & { _submittedData: any };
 
 export type GenericObject = { [key: string]: any };

--- a/packages/validation-tests/tests/inputProps.test.ts
+++ b/packages/validation-tests/tests/inputProps.test.ts
@@ -9,6 +9,7 @@ describe("getInputProps", () => {
   describe("initial", () => {
     it("should validate on blur by default", () => {
       const options: CreateGetInputPropsOptions = {
+        name: "some-field",
         defaultValue: "test default value",
         touched: false,
         hasBeenSubmitted: false,
@@ -40,6 +41,7 @@ describe("getInputProps", () => {
 
     it("should respect provided validation behavior", () => {
       const options: CreateGetInputPropsOptions = {
+        name: "some-field",
         defaultValue: "test default value",
         touched: false,
         hasBeenSubmitted: false,
@@ -74,6 +76,7 @@ describe("getInputProps", () => {
 
     it("should not validate when behavior is onSubmit", () => {
       const options: CreateGetInputPropsOptions = {
+        name: "some-field",
         defaultValue: "test default value",
         touched: false,
         hasBeenSubmitted: false,
@@ -110,6 +113,7 @@ describe("getInputProps", () => {
   describe("whenTouched", () => {
     it("should validate on change by default", () => {
       const options: CreateGetInputPropsOptions = {
+        name: "some-field",
         defaultValue: "test default value",
         touched: true,
         hasBeenSubmitted: false,
@@ -141,6 +145,7 @@ describe("getInputProps", () => {
 
     it("should respect provided validation behavior", () => {
       const options: CreateGetInputPropsOptions = {
+        name: "some-field",
         defaultValue: "test default value",
         touched: true,
         hasBeenSubmitted: false,
@@ -177,6 +182,7 @@ describe("getInputProps", () => {
   describe("whenSubmitted", () => {
     it("should validate on change by default", () => {
       const options: CreateGetInputPropsOptions = {
+        name: "some-field",
         defaultValue: "test default value",
         touched: true,
         hasBeenSubmitted: true,
@@ -208,6 +214,7 @@ describe("getInputProps", () => {
 
     it("should respect provided validation behavior", () => {
       const options: CreateGetInputPropsOptions = {
+        name: "some-field",
         defaultValue: "test default value",
         touched: true,
         hasBeenSubmitted: true,

--- a/packages/validation-tests/tests/inputProps.test.ts
+++ b/packages/validation-tests/tests/inputProps.test.ts
@@ -1,0 +1,243 @@
+import {
+  createGetInputProps,
+  CreateGetInputPropsOptions,
+} from "remix-validated-form/src/internal/getInputProps";
+
+const fakeEvent = { fake: "event" } as any;
+
+describe("getInputProps", () => {
+  describe("initial", () => {
+    it("should validate on blur by default", () => {
+      const options: CreateGetInputPropsOptions = {
+        defaultValue: "test default value",
+        touched: false,
+        hasBeenSubmitted: false,
+        setTouched: jest.fn(),
+        clearError: jest.fn(),
+        validate: jest.fn(),
+      };
+      const getInputProps = createGetInputProps(options);
+
+      const provided = {
+        onBlur: jest.fn(),
+        onChange: jest.fn(),
+      };
+      const { onChange, onBlur } = getInputProps(provided);
+
+      onChange!(fakeEvent);
+      expect(provided.onChange).toBeCalledTimes(1);
+      expect(provided.onChange).toBeCalledWith(fakeEvent);
+      expect(options.setTouched).not.toBeCalled();
+      expect(options.validate).not.toBeCalled();
+
+      onBlur!(fakeEvent);
+      expect(provided.onBlur).toBeCalledTimes(1);
+      expect(provided.onBlur).toBeCalledWith(fakeEvent);
+      expect(options.setTouched).toBeCalledTimes(1);
+      expect(options.setTouched).toBeCalledWith(true);
+      expect(options.validate).toBeCalledTimes(1);
+    });
+
+    it("should respect provided validation behavior", () => {
+      const options: CreateGetInputPropsOptions = {
+        defaultValue: "test default value",
+        touched: false,
+        hasBeenSubmitted: false,
+        setTouched: jest.fn(),
+        clearError: jest.fn(),
+        validate: jest.fn(),
+        validationBehavior: {
+          initial: "onChange",
+        },
+      };
+      const getInputProps = createGetInputProps(options);
+
+      const provided = {
+        onBlur: jest.fn(),
+        onChange: jest.fn(),
+      };
+      const { onChange, onBlur } = getInputProps(provided);
+
+      onChange!(fakeEvent);
+      expect(provided.onChange).toBeCalledTimes(1);
+      expect(provided.onChange).toBeCalledWith(fakeEvent);
+      expect(options.setTouched).not.toBeCalled();
+      expect(options.validate).toBeCalledTimes(1);
+
+      onBlur!(fakeEvent);
+      expect(provided.onBlur).toBeCalledTimes(1);
+      expect(provided.onBlur).toBeCalledWith(fakeEvent);
+      expect(options.setTouched).toBeCalledTimes(1);
+      expect(options.setTouched).toBeCalledWith(true);
+      expect(options.validate).toBeCalledTimes(1);
+    });
+
+    it("should not validate when behavior is onSubmit", () => {
+      const options: CreateGetInputPropsOptions = {
+        defaultValue: "test default value",
+        touched: false,
+        hasBeenSubmitted: false,
+        setTouched: jest.fn(),
+        clearError: jest.fn(),
+        validate: jest.fn(),
+        validationBehavior: {
+          initial: "onSubmit",
+        },
+      };
+      const getInputProps = createGetInputProps(options);
+
+      const provided = {
+        onBlur: jest.fn(),
+        onChange: jest.fn(),
+      };
+      const { onChange, onBlur } = getInputProps(provided);
+
+      onChange!(fakeEvent);
+      expect(provided.onChange).toBeCalledTimes(1);
+      expect(provided.onChange).toBeCalledWith(fakeEvent);
+      expect(options.setTouched).not.toBeCalled();
+      expect(options.validate).not.toBeCalled();
+
+      onBlur!(fakeEvent);
+      expect(provided.onBlur).toBeCalledTimes(1);
+      expect(provided.onBlur).toBeCalledWith(fakeEvent);
+      expect(options.setTouched).toBeCalledTimes(1);
+      expect(options.setTouched).toBeCalledWith(true);
+      expect(options.validate).not.toBeCalled();
+    });
+  });
+
+  describe("whenTouched", () => {
+    it("should validate on change by default", () => {
+      const options: CreateGetInputPropsOptions = {
+        defaultValue: "test default value",
+        touched: true,
+        hasBeenSubmitted: false,
+        setTouched: jest.fn(),
+        clearError: jest.fn(),
+        validate: jest.fn(),
+      };
+      const getInputProps = createGetInputProps(options);
+
+      const provided = {
+        onBlur: jest.fn(),
+        onChange: jest.fn(),
+      };
+      const { onChange, onBlur } = getInputProps(provided);
+
+      onChange!(fakeEvent);
+      expect(provided.onChange).toBeCalledTimes(1);
+      expect(provided.onChange).toBeCalledWith(fakeEvent);
+      expect(options.setTouched).not.toBeCalled();
+      expect(options.validate).toBeCalledTimes(1);
+
+      onBlur!(fakeEvent);
+      expect(provided.onBlur).toBeCalledTimes(1);
+      expect(provided.onBlur).toBeCalledWith(fakeEvent);
+      expect(options.setTouched).toBeCalledTimes(1);
+      expect(options.setTouched).toBeCalledWith(true);
+      expect(options.validate).toBeCalledTimes(1);
+    });
+
+    it("should respect provided validation behavior", () => {
+      const options: CreateGetInputPropsOptions = {
+        defaultValue: "test default value",
+        touched: true,
+        hasBeenSubmitted: false,
+        setTouched: jest.fn(),
+        clearError: jest.fn(),
+        validate: jest.fn(),
+        validationBehavior: {
+          whenTouched: "onBlur",
+        },
+      };
+      const getInputProps = createGetInputProps(options);
+
+      const provided = {
+        onBlur: jest.fn(),
+        onChange: jest.fn(),
+      };
+      const { onChange, onBlur } = getInputProps(provided);
+
+      onChange!(fakeEvent);
+      expect(provided.onChange).toBeCalledTimes(1);
+      expect(provided.onChange).toBeCalledWith(fakeEvent);
+      expect(options.setTouched).not.toBeCalled();
+      expect(options.validate).not.toBeCalled();
+
+      onBlur!(fakeEvent);
+      expect(provided.onBlur).toBeCalledTimes(1);
+      expect(provided.onBlur).toBeCalledWith(fakeEvent);
+      expect(options.setTouched).toBeCalledTimes(1);
+      expect(options.setTouched).toBeCalledWith(true);
+      expect(options.validate).toBeCalledTimes(1);
+    });
+  });
+
+  describe("whenSubmitted", () => {
+    it("should validate on change by default", () => {
+      const options: CreateGetInputPropsOptions = {
+        defaultValue: "test default value",
+        touched: true,
+        hasBeenSubmitted: true,
+        setTouched: jest.fn(),
+        clearError: jest.fn(),
+        validate: jest.fn(),
+      };
+      const getInputProps = createGetInputProps(options);
+
+      const provided = {
+        onBlur: jest.fn(),
+        onChange: jest.fn(),
+      };
+      const { onChange, onBlur } = getInputProps(provided);
+
+      onChange!(fakeEvent);
+      expect(provided.onChange).toBeCalledTimes(1);
+      expect(provided.onChange).toBeCalledWith(fakeEvent);
+      expect(options.setTouched).not.toBeCalled();
+      expect(options.validate).toBeCalledTimes(1);
+
+      onBlur!(fakeEvent);
+      expect(provided.onBlur).toBeCalledTimes(1);
+      expect(provided.onBlur).toBeCalledWith(fakeEvent);
+      expect(options.setTouched).toBeCalledTimes(1);
+      expect(options.setTouched).toBeCalledWith(true);
+      expect(options.validate).toBeCalledTimes(1);
+    });
+
+    it("should respect provided validation behavior", () => {
+      const options: CreateGetInputPropsOptions = {
+        defaultValue: "test default value",
+        touched: true,
+        hasBeenSubmitted: true,
+        setTouched: jest.fn(),
+        clearError: jest.fn(),
+        validate: jest.fn(),
+        validationBehavior: {
+          whenSubmitted: "onBlur",
+        },
+      };
+      const getInputProps = createGetInputProps(options);
+
+      const provided = {
+        onBlur: jest.fn(),
+        onChange: jest.fn(),
+      };
+      const { onChange, onBlur } = getInputProps(provided);
+
+      onChange!(fakeEvent);
+      expect(provided.onChange).toBeCalledTimes(1);
+      expect(provided.onChange).toBeCalledWith(fakeEvent);
+      expect(options.setTouched).not.toBeCalled();
+      expect(options.validate).not.toBeCalled();
+
+      onBlur!(fakeEvent);
+      expect(provided.onBlur).toBeCalledTimes(1);
+      expect(provided.onBlur).toBeCalledWith(fakeEvent);
+      expect(options.setTouched).toBeCalledTimes(1);
+      expect(options.setTouched).toBeCalledWith(true);
+      expect(options.validate).toBeCalledTimes(1);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6721,6 +6721,11 @@ ospath@^1.2.2:
   resolved "https://registry.yarnpkg.com/ospath/-/ospath-1.2.2.tgz#1276639774a3f8ef2572f7fe4280e0ea4550c07b"
   integrity sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=
 
+outdent@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/outdent/-/outdent-0.8.0.tgz#2ebc3e77bf49912543f1008100ff8e7f44428eb0"
+  integrity sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==
+
 p-cancelable@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.1.1.tgz#aab7fbd416582fa32a3db49859c122487c5ed2cf"


### PR DESCRIPTION
This adds a few small features that culminate in a simpler and more complete experience using `useField`.