### PR TITLE
fix typo on `MyInputProps` example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ type MyInputProps = {
   label: string;
 };
 
-export const MyInput = ({ name, label }: InputProps) => {
+export const MyInput = ({ name, label }: MyInputProps) => {
   const { error, getInputProps } = useField(name);
   return (
     <div>


### PR DESCRIPTION
just a simple typo fix on the README example

**PS:** I'm not sure what's the diff on the last line, probably a newline at the end; sorry, doing this edit through GitHub website itself