### PR TITLE
Add File helpder to `zod-form-data`

### DIFF
--- a/packages/zod-form-data/README.md
+++ b/packages/zod-form-data/README.md
@@ -163,6 +163,33 @@ the `FormData` will not include an entry for `myCheckbox` at all.
 
 ([Further reading](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#value))
 
+### file
+
+Transforms any empty File objects to `undefined` before validating.
+This makes it so empty files will fail required checks,
+allowing you to use `optional` for optional fields.
+If you call `zfd.file` with no arguments, it will assume the field is a required file by default.
+
+#### Usage
+
+```ts
+const const schema = zfd.formData({
+  requiredFile: zfd.file(),
+  optional: zfd.file().optional(),
+})
+```
+
+There is a unique case in Remix when using a CustomUploadHandler, 
+the field will be a `File` on the client side, but an ID string (or URL) after uploading on the server.
+
+In this case you will need the schema to switch to string on the server:
+
+```ts
+const const schema = (clientSide = true) => zfd.formData({
+  file: clientSide ? zfd.file() : zfd.file(z.string()),
+})
+```
+
 ### repeatable
 
 Preprocesses a field where you expect multiple values could be present for the same field name

--- a/packages/zod-form-data/README.md
+++ b/packages/zod-form-data/README.md
@@ -173,7 +173,7 @@ If you call `zfd.file` with no arguments, it will assume the field is a required
 #### Usage
 
 ```ts
-const const schema = zfd.formData({
+const schema = zfd.formData({
   requiredFile: zfd.file(),
   optional: zfd.file().optional(),
 })
@@ -185,10 +185,12 @@ the field will be a `File` on the client side, but an ID string (or URL) after u
 In this case you will need the schema to switch to string on the server:
 
 ```ts
-const const schema = (clientSide = true) => zfd.formData({
+const schema = (clientSide = true) => zfd.formData({
   file: clientSide ? zfd.file() : zfd.file(z.string()),
 })
 ```
+
+*Note: This will return `File | string` for the type. TODO: Example of type safety for this* 
 
 ### repeatable
 

--- a/packages/zod-form-data/src/helpers.ts
+++ b/packages/zod-form-data/src/helpers.ts
@@ -42,8 +42,8 @@ export const checkbox = ({ trueValue = "on" }: CheckboxOpts = {}) =>
     z.literal(undefined).transform(() => false),
   ]);
 
-export const file: InputType<ZodTypeAny> = (schema = z.instanceof(File)) =>
-  z.preprocess(val => {
+export const file: InputType<z.ZodType<File>> = (schema = z.instanceof(File)) =>
+  z.preprocess((val) => {
     //Empty File object on no user input, so convert to undefined
     return val instanceof File && val.size === 0 ? undefined : val;
   }, schema);

--- a/packages/zod-form-data/src/helpers.ts
+++ b/packages/zod-form-data/src/helpers.ts
@@ -42,6 +42,12 @@ export const checkbox = ({ trueValue = "on" }: CheckboxOpts = {}) =>
     z.literal(undefined).transform(() => false),
   ]);
 
+export const file: InputType<ZodTypeAny> = (schema = z.instanceof(File)) =>
+  z.preprocess(val => {
+    //Empty File object on no user input, so convert to undefined
+    return val instanceof File && val.size === 0 ? undefined : val;
+  }, schema));
+
 export const repeatable: InputType<ZodArray<any>> = (
   schema = z.array(text())
 ) => {

--- a/packages/zod-form-data/src/helpers.ts
+++ b/packages/zod-form-data/src/helpers.ts
@@ -46,7 +46,7 @@ export const file: InputType<ZodTypeAny> = (schema = z.instanceof(File)) =>
   z.preprocess(val => {
     //Empty File object on no user input, so convert to undefined
     return val instanceof File && val.size === 0 ? undefined : val;
-  }, schema));
+  }, schema);
 
 export const repeatable: InputType<ZodArray<any>> = (
   schema = z.array(text())


### PR DESCRIPTION
This is kind of a weird one, that I just did the implementation of locally and figured could go in here as well.

Would definitely recommend double checking it's use cases, as the whole File thing is a bit dodgy with Remix at the moment :) 

The CustomUploadHandler bit is also a bit different to document, as the dev can realistically convert the File to whatever they want after handling the upload