### PR TITLE
FileObject helper for switching Server / Client side

### DIFF
--- a/packages/zod-form-data/README.md
+++ b/packages/zod-form-data/README.md
@@ -175,22 +175,23 @@ If you call `zfd.file` with no arguments, it will assume the field is a required
 ```ts
 const schema = zfd.formData({
   requiredFile: zfd.file(),
-  optional: zfd.file().optional(),
 })
 ```
 
 There is a unique case in Remix when using a CustomUploadHandler, 
-the field will be a `File` on the client side, but an ID string (or URL) after uploading on the server.
+the field will be a `File` on the client side, but an ID string / number / url after uploading on the server.
 
-In this case you will need the schema to switch to string on the server:
+In this case you will need the schema to switch types on the server, and that's where `zfd.fileObject()` comes in.
 
 ```ts
-const schema = (clientSide = true) => zfd.formData({
-  file: clientSide ? zfd.file() : zfd.file(z.string()),
-})
-```
+//Create the base schema without your files
+const baseSchema = z.object({
+  description: zfd.text(),
+});
 
-*Note: This will return `File | string` for the type. TODO: Example of type safety for this* 
+const clientValidator = withZod(baseSchema.and(zfd.fileObject('myFileKey'))) //Defaults to File
+const serverValidator = withZod(baseSchema.and(zfd.fileObject('myFileKey', z.string())))
+```
 
 ### repeatable
 

--- a/packages/zod-form-data/README.md
+++ b/packages/zod-form-data/README.md
@@ -190,25 +190,19 @@ const schema = zfd.formData({
 ```
 
 There is a unique case in Remix when using a CustomUploadHandler, 
-the field will be a `File` on the client side, but an ID string (or URL) after uploading on the server.
+the field will be a `File` on the client side, but an ID string / number / url after uploading on the server.
 
-In this case you will need the schema to switch to string on the server:
+In this case you will need the schema to switch types on the server, and that's where `zfd.fileObject()` comes in.
 
 ```ts
+//Create the base schema without your files
 const baseSchema = z.object({
-  someOtherField: zfd.text(),
+  description: zfd.text(),
 });
 
-const clientSchema = z.formData(baseSchema.and({
-  file: zfd.file()
-}))
-
-const serverSchema = z.formData(baseSchema.and({
-  file: z.string()
-}))
+const clientValidator = withZod(baseSchema.and(zfd.fileObject('myFileKey'))) //Defaults to File
+const serverValidator = withZod(baseSchema.and(zfd.fileObject('myFileKey', z.string())))
 ```
-
-*Note: This will return `File | string` for the type. TODO: Example of type safety for this* 
 
 ### repeatable
 

--- a/packages/zod-form-data/README.md
+++ b/packages/zod-form-data/README.md
@@ -175,23 +175,22 @@ If you call `zfd.file` with no arguments, it will assume the field is a required
 ```ts
 const schema = zfd.formData({
   requiredFile: zfd.file(),
+  optional: zfd.file().optional(),
 })
 ```
 
 There is a unique case in Remix when using a CustomUploadHandler, 
-the field will be a `File` on the client side, but an ID string / number / url after uploading on the server.
+the field will be a `File` on the client side, but an ID string (or URL) after uploading on the server.
 
-In this case you will need the schema to switch types on the server, and that's where `zfd.fileObject()` comes in.
+In this case you will need the schema to switch to string on the server:
 
 ```ts
-//Create the base schema without your files
-const baseSchema = z.object({
-  description: zfd.text(),
-});
-
-const clientValidator = withZod(baseSchema.and(zfd.fileObject('myFileKey'))) //Defaults to File
-const serverValidator = withZod(baseSchema.and(zfd.fileObject('myFileKey', z.string())))
+const schema = (clientSide = true) => zfd.formData({
+  file: clientSide ? zfd.file() : zfd.file(z.string()),
+})
 ```
+
+*Note: This will return `File | string` for the type. TODO: Example of type safety for this* 
 
 ### repeatable
 

--- a/packages/zod-form-data/src/helpers.ts
+++ b/packages/zod-form-data/src/helpers.ts
@@ -63,7 +63,7 @@ interface FileObject {
   }>;
   <Key extends string, ProvidedType extends z.ZodTypeAny>(
     key: Key,
-    serverType?: ProvidedType
+    serverType: ProvidedType
   ): z.ZodObject<{
     [key in Key]: z.ZodEffects<ProvidedType>;
   }>;

--- a/packages/zod-form-data/src/helpers.ts
+++ b/packages/zod-form-data/src/helpers.ts
@@ -57,6 +57,25 @@ export const file: InputType<z.ZodType<File>> = (schema = z.instanceof(File)) =>
     return val instanceof File && val.size === 0 ? undefined : val;
   }, schema);
 
+interface FileObject {
+  <Key extends string>(key: Key): z.ZodObject<{
+    [key in Key]: z.ZodEffects<z.ZodType<File>>;
+  }>;
+  <Key extends string, ProvidedType extends z.ZodTypeAny>(
+    key: Key,
+    serverType?: ProvidedType
+  ): z.ZodObject<{
+    [key in Key]: z.ZodEffects<ProvidedType>;
+  }>;
+}
+
+//This is the correct typing but I can't figure out the TS error
+export const fileObject: FileObject = (key, serverType) => {
+  return z.object({
+    [key]: serverType ? file(serverType) : file(),
+  });
+};
+
 export const repeatable: InputType<ZodArray<any>> = (
   schema = z.array(text())
 ) => {

--- a/packages/zod-form-data/src/helpers.ts
+++ b/packages/zod-form-data/src/helpers.ts
@@ -48,6 +48,25 @@ export const file: InputType<z.ZodType<File>> = (schema = z.instanceof(File)) =>
     return val instanceof File && val.size === 0 ? undefined : val;
   }, schema);
 
+interface FileObject {
+  <Key extends string>(key: Key): z.ZodObject<{
+    [key in Key]: z.ZodEffects<z.ZodType<File>>;
+  }>;
+  <Key extends string, ProvidedType extends z.ZodTypeAny>(
+    key: Key,
+    serverType?: ProvidedType
+  ): z.ZodObject<{
+    [key in Key]: z.ZodEffects<ProvidedType>;
+  }>;
+}
+
+//This is the correct typing but I can't figure out the TS error
+export const fileObject: FileObject = (key, serverType) => {
+  return z.object({
+    [key]: serverType ? file(serverType) : file(),
+  });
+};
+
 export const repeatable: InputType<ZodArray<any>> = (
   schema = z.array(text())
 ) => {

--- a/packages/zod-form-data/src/helpers.ts
+++ b/packages/zod-form-data/src/helpers.ts
@@ -48,25 +48,6 @@ export const file: InputType<z.ZodType<File>> = (schema = z.instanceof(File)) =>
     return val instanceof File && val.size === 0 ? undefined : val;
   }, schema);
 
-interface FileObject {
-  <Key extends string>(key: Key): z.ZodObject<{
-    [key in Key]: z.ZodEffects<z.ZodType<File>>;
-  }>;
-  <Key extends string, ProvidedType extends z.ZodTypeAny>(
-    key: Key,
-    serverType?: ProvidedType
-  ): z.ZodObject<{
-    [key in Key]: z.ZodEffects<ProvidedType>;
-  }>;
-}
-
-//This is the correct typing but I can't figure out the TS error
-export const fileObject: FileObject = (key, serverType) => {
-  return z.object({
-    [key]: serverType ? file(serverType) : file(),
-  });
-};
-
 export const repeatable: InputType<ZodArray<any>> = (
   schema = z.array(text())
 ) => {


### PR DESCRIPTION
Just raising this PR even though it's not done... something is wrong with the function itself, but the Types are what you'd expect.

`zfd.fileObject('myKey')`

will result in the type

```
{
  myKey: File
}
```