### PR TITLE
docs: Fix a variable name and includes a missing piece

### DIFF
--- a/apps/docs/app/routes/integrate-your-components.mdx
+++ b/apps/docs/app/routes/integrate-your-components.mdx
@@ -33,7 +33,7 @@ type MyInputProps = {
   label: string;
 };
 
-export const MyInput = ({ name, label }: InputProps) => {
+export const MyInput = ({ name, label }: MyInputProps) => {
   const { error, getInputProps } = useField(name);
   return (
     <div>
@@ -70,6 +70,8 @@ export const MySubmitButton = () => {
 Now, we can create a fully validated form with minimal boilerplate.
 
 ```tsx
+import { ValidatedForm } from 'remix-validated-form';
+
 export const validator = withZod(
   z.object({
     firstName: z

--- a/apps/docs/app/routes/integrate-your-components.mdx
+++ b/apps/docs/app/routes/integrate-your-components.mdx
@@ -71,6 +71,8 @@ Now, we can create a fully validated form with minimal boilerplate.
 
 ```tsx
 import { ValidatedForm } from 'remix-validated-form';
+import { withZod } from "@remix-validated-form/with-zod";
+import { z } from "zod";
 
 export const validator = withZod(
   z.object({


### PR DESCRIPTION
Fix the mismatching interface names:
![CleanShot 2022-01-27 at 19 36 46](https://user-images.githubusercontent.com/151001/151425442-075e3b5e-f70e-4efd-990d-f6997e052542.png)

Includes the import, so it is clear where the `<ValidatedForm>` is coming from
![CleanShot 2022-01-27 at 19 33 06](https://user-images.githubusercontent.com/151001/151425447-05cabf8a-e461-4ec3-bae4-6a3c6327a402.png)
