### PR TITLE
Remix validated form 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ const validator = withYup(
 );
 
 export const action: ActionFunction = async ({ request }) => {
-  const fieldValues = validator.validate(await request.formData());
+  const fieldValues = await validator.validate(await request.formData());
   if (fieldValues.error) return validationError(fieldValues.error);
   const { firstName, lastName, email } = fieldValues.data;
 

--- a/apps/docs/app/components/Alert.tsx
+++ b/apps/docs/app/components/Alert.tsx
@@ -1,11 +1,12 @@
 import {
+  CheckCircleIcon,
   InformationCircleIcon,
   XCircleIcon,
 } from "@heroicons/react/solid";
 import classNames from "classnames";
 import { FC, ReactNode } from "react";
 
-export type AlertVariants = "error" | "info";
+export type AlertVariants = "error" | "info" | "success";
 
 export type AlertProps = {
   title?: string;
@@ -18,6 +19,7 @@ export type AlertProps = {
 const variantIcons = {
   error: XCircleIcon,
   info: InformationCircleIcon,
+  success: CheckCircleIcon,
 };
 
 export const Alert: FC<AlertProps> = ({
@@ -35,6 +37,8 @@ export const Alert: FC<AlertProps> = ({
         "rounded-md p-4 border border-red-400",
         variant === "error" && "border-red-400 bg-red-50",
         variant === "info" && "border-blue-400 bg-blue-50",
+        variant === "success" &&
+          "border-green-400 bg-green-50",
         className
       )}
     >
@@ -44,7 +48,8 @@ export const Alert: FC<AlertProps> = ({
             className={classNames(
               "h-5 w-5",
               variant === "error" && "text-red-500",
-              variant === "info" && "text-blue-500"
+              variant === "info" && "text-blue-500",
+              variant === "success" && "text-green-500"
             )}
           />
         </div>
@@ -54,7 +59,8 @@ export const Alert: FC<AlertProps> = ({
               className={classNames(
                 "text-sm font-medium",
                 variant === "error" && "text-red-800",
-                variant === "info" && "text-blue-800"
+                variant === "info" && "text-blue-800",
+                variant === "success" && "text-green-800"
               )}
             >
               {title}
@@ -66,7 +72,8 @@ export const Alert: FC<AlertProps> = ({
                 "text-sm",
                 !!title && "mt-2",
                 variant === "error" && "text-red-700",
-                variant === "info" && "text-blue-700"
+                variant === "info" && "text-blue-700",
+                variant === "success" && "text-green-700"
               )}
             >
               {details}

--- a/apps/docs/app/components/Layout.tsx
+++ b/apps/docs/app/components/Layout.tsx
@@ -59,6 +59,10 @@ const navSections: Section[] = [
         to: "/reference/use-is-submitting",
       },
       {
+        label: "useIsValid",
+        to: "/reference/use-is-valid",
+      },
+      {
         label: "useFormContext",
         to: "/reference/use-form-context",
       },

--- a/apps/docs/app/components/Layout.tsx
+++ b/apps/docs/app/components/Layout.tsx
@@ -45,6 +45,10 @@ const navSections: Section[] = [
         label: "Validation library support",
         to: "/validation-library-support",
       },
+      {
+        label: "Supporting users without JS",
+        to: "/supporting-no-js",
+      },
     ],
   },
   {

--- a/apps/docs/app/components/Layout.tsx
+++ b/apps/docs/app/components/Layout.tsx
@@ -38,6 +38,10 @@ const navSections: Section[] = [
         to: "/arrays-and-nested",
       },
       {
+        label: "Async Validation",
+        to: "/async-validation",
+      },
+      {
         label: "Validation library support",
         to: "/validation-library-support",
       },

--- a/apps/docs/app/examples/asyncValidation.tsx
+++ b/apps/docs/app/examples/asyncValidation.tsx
@@ -16,6 +16,9 @@ import { FormInput } from "~/components/FormInput";
 import { SubmitButton } from "~/components/SubmitButton";
 import { db } from "~/examples/usernameExists/db";
 
+/**
+ * The base schema for our form.
+ */
 const schema = z
   .object({
     username: zfd.text(),
@@ -30,13 +33,16 @@ const schema = z
       message: "Passwords must match",
     }
   );
+
+/**
+ * The client version of our validator
+ */
 const clientValidator = withZod(schema);
 
-type UsernameCheckReturnType = {
-  usernameTaken: boolean;
-  suggestions: string[];
-};
-
+/**
+ * In our action we create a second, server-side validation that checks if the
+ * username exists in the database already.
+ */
 export const action: ActionFunction = async ({
   request,
 }) => {
@@ -54,6 +60,7 @@ export const action: ActionFunction = async ({
     )
   );
 
+  // Since the db check is already in the schema, we can continue on as normal
   const result = await serverValidator.validate(
     await request.formData()
   );
@@ -66,8 +73,10 @@ export const action: ActionFunction = async ({
  * An input component that checks if a username is taken.
  */
 const UsernameInput = () => {
-  const usernameCheckFetcher =
-    useFetcher<UsernameCheckReturnType>();
+  const usernameCheckFetcher = useFetcher<{
+    usernameTaken: boolean;
+    suggestions: string[];
+  }>();
 
   const getUsernameMessage = () => {
     if (usernameCheckFetcher.state === "loading")
@@ -129,6 +138,9 @@ const UsernameInput = () => {
   );
 };
 
+/**
+ * Our actual route component
+ */
 export default function AsyncValidation() {
   const data = useActionData();
   return (

--- a/apps/docs/app/examples/asyncValidation.tsx
+++ b/apps/docs/app/examples/asyncValidation.tsx
@@ -1,0 +1,156 @@
+import { withZod } from "@remix-validated-form/with-zod";
+import {
+  ActionFunction,
+  json,
+  useActionData,
+  useFetcher,
+} from "remix";
+import {
+  ValidatedForm,
+  validationError,
+} from "remix-validated-form";
+import { z } from "zod";
+import { zfd } from "zod-form-data";
+import { Alert } from "~/components/Alert";
+import { FormInput } from "~/components/FormInput";
+import { SubmitButton } from "~/components/SubmitButton";
+import { db } from "~/examples/usernameExists/db";
+
+const schema = z
+  .object({
+    username: zfd.text(),
+    password: zfd.text(),
+    passwordConfirm: zfd.text(),
+  })
+  .refine(
+    ({ password, passwordConfirm }) =>
+      password === passwordConfirm,
+    {
+      path: ["passwordConfirm"],
+      message: "Passwords must match",
+    }
+  );
+const clientValidator = withZod(schema);
+
+type UsernameCheckReturnType = {
+  usernameTaken: boolean;
+  suggestions: string[];
+};
+
+export const action: ActionFunction = async ({
+  request,
+}) => {
+  const serverValidator = withZod(
+    schema.refine(
+      async (data) => {
+        const usernameAvailable =
+          await db.isUsernameAvailable(data.username);
+        return usernameAvailable;
+      },
+      {
+        message: "Whoops! That username is taken.",
+        path: ["username"],
+      }
+    )
+  );
+
+  const result = await serverValidator.validate(
+    await request.formData()
+  );
+  if (result.error) return validationError(result.error);
+
+  return json({ message: "You got the username!" });
+};
+
+/**
+ * An input component that checks if a username is taken.
+ */
+const UsernameInput = () => {
+  const usernameCheckFetcher =
+    useFetcher<UsernameCheckReturnType>();
+
+  const getUsernameMessage = () => {
+    if (usernameCheckFetcher.state === "loading")
+      return (
+        <Alert
+          variant="info"
+          title="Checking username..."
+        />
+      );
+
+    if (!usernameCheckFetcher.data) return null;
+
+    const { usernameTaken, suggestions } =
+      usernameCheckFetcher.data;
+
+    if (usernameTaken)
+      return (
+        <Alert
+          variant="error"
+          title="That username is taken, but one of these would work"
+          details={
+            <ul>
+              {suggestions.map((suggestion) => (
+                <li key={suggestion}>{suggestion}</li>
+              ))}
+            </ul>
+          }
+        />
+      );
+
+    return (
+      <Alert
+        variant="success"
+        title="That username is available!"
+      />
+    );
+  };
+
+  return (
+    <div className="space-y-2">
+      <FormInput
+        name="username"
+        label="Username"
+        onBlur={(event) => {
+          const username = event.target.value;
+          if (username) {
+            // Ping our api to see if the username is taken.
+            usernameCheckFetcher.load(
+              `/username-exists?username=${username}`
+            );
+          }
+
+          // We could do this onChange too, but we would need to
+          // make sure we throttle or debounce the requests.
+        }}
+      />
+      {getUsernameMessage()}
+    </div>
+  );
+};
+
+export default function AsyncValidation() {
+  const data = useActionData();
+  return (
+    <ValidatedForm
+      validator={clientValidator}
+      method="post"
+    >
+      <UsernameInput />
+      <FormInput
+        type="password"
+        name="password"
+        label="Password"
+      />
+      <FormInput
+        type="password"
+        name="passwordConfirm"
+        label="Confirm Password"
+      />
+      {data?.message && (
+        <Alert variant="success" title={data.message} />
+      )}
+      <SubmitButton />
+    </ValidatedForm>
+  );
+}

--- a/apps/docs/app/examples/checkboxGroups.tsx
+++ b/apps/docs/app/examples/checkboxGroups.tsx
@@ -19,7 +19,7 @@ export const validator = withZod(
 export const action: ActionFunction = async ({
   request,
 }) => {
-  const result = validator.validate(
+  const result = await validator.validate(
     await request.formData()
   );
   if (result.error) return validationError(result.error);

--- a/apps/docs/app/examples/demo.tsx
+++ b/apps/docs/app/examples/demo.tsx
@@ -25,7 +25,9 @@ export const validator = withZod(
 export const action: ActionFunction = async ({
   request,
 }) => {
-  const data = validator.validate(await request.formData());
+  const data = await validator.validate(
+    await request.formData()
+  );
   if (data.error) return validationError(data.error);
   const { firstName, lastName, email } = data.data;
 

--- a/apps/docs/app/examples/demo.tsx
+++ b/apps/docs/app/examples/demo.tsx
@@ -28,8 +28,7 @@ export const action: ActionFunction = async ({
   const data = await validator.validate(
     await request.formData()
   );
-  if (data.error)
-    return validationError(data.error, data.submittedData);
+  if (data.error) return validationError(data.error);
   const { firstName, lastName, email } = data.data;
 
   return json({

--- a/apps/docs/app/examples/demo.tsx
+++ b/apps/docs/app/examples/demo.tsx
@@ -28,7 +28,8 @@ export const action: ActionFunction = async ({
   const data = await validator.validate(
     await request.formData()
   );
-  if (data.error) return validationError(data.error);
+  if (data.error)
+    return validationError(data.error, data.submittedData);
   const { firstName, lastName, email } = data.data;
 
   return json({

--- a/apps/docs/app/examples/nestedData.tsx
+++ b/apps/docs/app/examples/nestedData.tsx
@@ -40,7 +40,7 @@ type ActionData = {
 export const action: ActionFunction = async ({
   request,
 }) => {
-  const result = validator.validate(
+  const result = await validator.validate(
     await request.formData()
   );
   if (result.error) return validationError(result.error);

--- a/apps/docs/app/examples/usernameExists/db.ts
+++ b/apps/docs/app/examples/usernameExists/db.ts
@@ -1,0 +1,16 @@
+export const db = {
+  isUsernameAvailable: async (username: string) => {
+    await new Promise((resolve) =>
+      setTimeout(resolve, 1000)
+    );
+
+    if (
+      username.endsWith("123") ||
+      username.endsWith("234")
+    ) {
+      return true;
+    }
+
+    return false;
+  },
+};

--- a/apps/docs/app/routes/async-validation.mdx
+++ b/apps/docs/app/routes/async-validation.mdx
@@ -1,0 +1,20 @@
+---
+meta:
+  title: Server validation (Remix Validated Form)
+---
+
+import { CodeExample } from "~/components/CodeExample";
+import Demo, { action } from "~/examples/asyncValidation";
+
+export { action };
+
+# Async validation
+
+<CodeExample>
+  <Demo />
+
+```tsx file=~/examples/asyncValidation.tsx
+
+```
+
+</CodeExample>

--- a/apps/docs/app/routes/async-validation.mdx
+++ b/apps/docs/app/routes/async-validation.mdx
@@ -1,6 +1,6 @@
 ---
 meta:
-  title: Server validation (Remix Validated Form)
+  title: Async validation (Remix Validated Form)
 ---
 
 import { CodeExample } from "~/components/CodeExample";
@@ -9,6 +9,44 @@ import Demo, { action } from "~/examples/asyncValidation";
 export { action };
 
 # Async validation
+
+If you're using a validation library that supports async validation,
+you can take full advantage of that on both the client and the server.
+
+## Client side
+
+On the client side, your validation schema is not the best place to make calls to an api.
+There are a couple reasons for this:
+
+- The user shouldn't have to wait for unnecessary API calls before the actual form submit.
+  You need to validate in your action anyway, so it's better to do those validations there.
+- For some validation libraries (like `zod`),
+  it's not possible to run only the validations for one field.
+  This means that all your async validations get run any time you change a single field.
+
+Async validation on the client is primarily for those cases where something _needs_ to be async,
+but it still doesn't take longer than a few milliseconds for the most part.
+In some cases you might want to hit your api to perform some checks,
+but in those cases it's probably best to do so using `useFetcher`.
+
+## Server side
+
+On the server, you can put absolutely anything you want in your validation schema.
+In fact, this can be a good way to add extra checks like checking if a username is already taken.
+This does mean keeping separate client & server validators based on the same schema,
+but with libraries like `yup` and `zod`, it's possible to have one base schema and augment it
+as needed.
+
+## Example
+
+In this example, we have a basic sign-up form.
+
+Often, it's a good idea in this sort of form to provide some information to the user about
+whether or not their username is takne before they actually submit.
+We're providing that information here by using the `useFetcher` hook.
+
+Then, on the server side, we're using the `refine` method on the base zod schema,
+to add an async database query to the validation schema.
 
 <CodeExample>
   <Demo />

--- a/apps/docs/app/routes/reference/use-field.mdx
+++ b/apps/docs/app/routes/reference/use-field.mdx
@@ -15,9 +15,6 @@ import { PropHeader } from "~/components/PropHeader";
 Accepts the `name` of the field and returns
 data about the field and helper functions for the field.
 This only works if used inside the context of a `ValidatedForm`.
-It is still safe to use this hook outside of a `ValidatedForm`,
-but there will be no `error` or `defaultValue`
-and the helpers will be no-ops.
 
 ## FieldProps
 
@@ -52,7 +49,7 @@ The default value of the field, if there is one.
 
 Clears the error message.
 
-<PropHeader prop="validate" type="() => Promise<void>" />
+<PropHeader prop="validate" type="() => void" />
 
 Validates the form field and populates the `error` prop if there is an error.
 

--- a/apps/docs/app/routes/reference/use-field.mdx
+++ b/apps/docs/app/routes/reference/use-field.mdx
@@ -52,7 +52,7 @@ The default value of the field, if there is one.
 
 Clears the error message.
 
-<PropHeader prop="validate" type="() => void" />
+<PropHeader prop="validate" type="() => Promise<void>" />
 
 Validates the form field and populates the `error` prop if there is an error.
 

--- a/apps/docs/app/routes/reference/use-form-context.mdx
+++ b/apps/docs/app/routes/reference/use-form-context.mdx
@@ -81,7 +81,7 @@ Clear the errors from all the specified fields.
 
 <PropHeader
   prop="validatedField"
-  type="(fieldName: string) => void"
+  type="(fieldName: string) => Promise<void>"
 />
 
 Performs validation on the specified field and populates `fieldErrors` if there is an error.

--- a/apps/docs/app/routes/reference/use-form-context.mdx
+++ b/apps/docs/app/routes/reference/use-form-context.mdx
@@ -14,6 +14,9 @@ import { PropHeader } from "~/components/PropHeader";
 Uses the context api to return the value of the current form context.
 This should be used within the context of a `ValidatedForm`.
 
+_Note:_ It is generally recommended to use more specific hooks rather than accessing the form context directly.
+It is provided for use in more complex or advanced cases.
+
 #### Usage
 
 _Correct_: This will work because it's used within the context of a `ValidatedForm`.
@@ -80,11 +83,12 @@ Whether or not the form valid.
 Clear the errors from all the specified fields.
 
 <PropHeader
-  prop="validatedField"
-  type="(fieldName: string) => Promise<void>"
+  prop="validateField"
+  type="(fieldName: string) => Promise<string | null>"
 />
 
 Performs validation on the specified field and populates `fieldErrors` if there is an error.
+Also returns the error message if there is an error.
 
 <PropHeader prop="action" type="string | undefined" />
 

--- a/apps/docs/app/routes/reference/use-is-valid.mdx
+++ b/apps/docs/app/routes/reference/use-is-valid.mdx
@@ -1,15 +1,15 @@
 ---
 meta:
-  title: useIsSubmitting (Remix Validated Form)
+  title: useIsValid (Remix Validated Form)
 ---
 
 import { PropHeader } from "~/components/PropHeader";
 
 <PropHeader
   variant="h1"
-  prop="useIsSubmitting"
+  prop="useIsValid"
   type="() => boolean"
 />
 
-A hook that returns whether or not the current form is being submitted.
+A hook that returns whether or not the current form valid.
 This only works if used inside the context of a `ValidatedForm`.

--- a/apps/docs/app/routes/reference/validation-error.mdx
+++ b/apps/docs/app/routes/reference/validation-error.mdx
@@ -13,8 +13,6 @@ import { PropHeader } from "~/components/PropHeader";
 
 Accepts the errors returned from `validator.validate` and returns a response.
 The `ValidatedForm` on the page will automatically receive these errors and display them.
-You can also pass a second argument to repopulate the form with the data that was submitted
-in cases where the user has javascript disabled.
 
 Most of the time, your code will look like this:
 
@@ -23,16 +21,28 @@ const action: ActionFunction = async ({ request }) => {
   const result = await validator.validate(
     await request.formData()
   );
-  if (result.error)
-    return validationError(
-      result.error,
-      result.submittedData
-    );
+  if (result.error) return validationError(result.error);
   // do something with result.data
 };
 ```
 
-## Omitting data from the second argument
+## Repopulating form data
+
+You can also pass a second argument to `validationError` to repopulate the form
+with the data that was submitted in cases where the user has javascript disabled.
+
+_Caveat_: Repopulating the form sets new default values.
+If the form has a reset button, clicking it will reset the form to the repopulated data,
+_not_ the original default values.
+If supporting the no-javascript case is not important to you,
+you might be better off omitting the second argument.
+
+_Caveat 2_: If your schema is doing transformations on the data after its validated,
+you may be opting into extra work for supporting `defaultValues`.
+Normally, when you pass `defaultValues` to a `ValidatedForm`, the type of that data
+is the final, validated, and transformed version of your data.
+But when you return `result.submittedData`, you're returning the original data
+(with the [nested object and array transformations](/arrays-and-nested) applied).
 
 In some cases, you might not want to return all the data the user submitted as part of your response.
 In those cases, you can omit some fields or not pass a second argument at all.
@@ -49,12 +59,12 @@ return validationError(result.error);
 
 ## Supporting additional validations
 
+_Note:_ Most use-cases for this can be better solved using [async validation](/async-validation).
+
 Sometimes you might want to run some additional checks on the data beyond what the validator can do.
 For example, if you have a signup form, you might want to check if a username already exists
 in the database before allowing the user to be created.
 In those cases, you can manually construct a `ValidatorError` object.
-
-_Note:_ You can also cover a lot of these cases using [async validation](/async-validation).
 
 ```tsx
 const action: ActionFunction = async ({ request }) => {

--- a/apps/docs/app/routes/reference/validation-error.mdx
+++ b/apps/docs/app/routes/reference/validation-error.mdx
@@ -20,7 +20,7 @@ For the vast majority of cases, your code will look like this:
 
 ```tsx
 const action: ActionFunction = async ({ request }) => {
-  const result = validator.validate(
+  const result = await validator.validate(
     await request.formData()
   );
   if (result.error) return validationError(result.error);
@@ -46,7 +46,7 @@ It's only when we start doing additional validations like this that it becomes n
 const action: ActionFunction = async ({ request }) => {
   // We should check the correctness of the data first,
   // before doing our custom check
-  const result = validator.validate(
+  const result = await validator.validate(
     await request.formData()
   );
   if (result.error) return validationError(result.error);

--- a/apps/docs/app/routes/reference/validation-error.mdx
+++ b/apps/docs/app/routes/reference/validation-error.mdx
@@ -8,24 +8,43 @@ import { PropHeader } from "~/components/PropHeader";
 <PropHeader
   variant="h1"
   prop="validationError"
-  type="(fieldErrors: Record<string, string>, submittedData?: unknown) => Response"
+  type="(fieldErrors: ValidatorError, submittedData?: unknown) => Response"
 />
 
 Accepts the errors returned from `validator.validate` and returns a response.
 The `ValidatedForm` on the page will automatically receive these errors and display them.
-This takes care of situations where the validation doesn't work on the client
-because the user has javascript disabled.
+You can also pass a second argument to repopulate the form with the data that was submitted
+in cases where the user has javascript disabled.
 
-For the vast majority of cases, your code will look like this:
+Most of the time, your code will look like this:
 
 ```tsx
 const action: ActionFunction = async ({ request }) => {
   const result = await validator.validate(
     await request.formData()
   );
-  if (result.error) return validationError(result.error);
+  if (result.error)
+    return validationError(
+      result.error,
+      result.submittedData
+    );
   // do something with result.data
 };
+```
+
+## Omitting data from the second argument
+
+In some cases, you might not want to return all the data the user submitted as part of your response.
+In those cases, you can omit some fields or not pass a second argument at all.
+
+```ts
+// Omitting some fields
+const { password, confirmPassword, ...rest } =
+  result.submittedData;
+return validationError(result.error, rest);
+
+// Omitting the second argument
+return validationError(result.error);
 ```
 
 ## Supporting additional validations
@@ -33,14 +52,7 @@ const action: ActionFunction = async ({ request }) => {
 Sometimes you might want to run some additional checks on the data beyond what the validator can do.
 For example, if you have a signup form, you might want to check if a username already exists
 in the database before allowing the user to be created.
-In those cases, we may want to use the second argument of `validationError`.
-
-The second argument of `validationError` allows you to specify
-what data was used to submit the form. This is **usually not necessary**.
-For the vast majority of cases (like in the example above),
-the submitted data is already being returned as part of the response
-and you don't need to do it yourself.
-It's only when we start doing additional validations like this that it becomes necessary.
+In those cases, you can manually construct a `ValidatorError` object.
 
 ```tsx
 const action: ActionFunction = async ({ request }) => {
@@ -57,7 +69,16 @@ const action: ActionFunction = async ({ request }) => {
   // vary depending on your own database solution
   if (await userExistsInDatabase(username)) {
     return validationError(
-      { username: "This username is already taken" },
+      {
+        fieldErrors: {
+          username: "This username is already taken",
+        },
+        // 🚨 Important!
+        // If you're using the `subaction` prop,
+        // you need to specify a subaction here
+        // or else the errors won't be displayed.
+        subaction: result.data.subaction,
+      },
       result.data
     );
   }

--- a/apps/docs/app/routes/reference/validation-error.mdx
+++ b/apps/docs/app/routes/reference/validation-error.mdx
@@ -54,6 +54,8 @@ For example, if you have a signup form, you might want to check if a username al
 in the database before allowing the user to be created.
 In those cases, you can manually construct a `ValidatorError` object.
 
+_Note:_ You can also cover a lot of these cases using [async validation](/async-validation).
+
 ```tsx
 const action: ActionFunction = async ({ request }) => {
   // We should check the correctness of the data first,

--- a/apps/docs/app/routes/server-validation.mdx
+++ b/apps/docs/app/routes/server-validation.mdx
@@ -35,7 +35,7 @@ We can re-use this validator in our action like this.
 export const action: ActionFunction = async ({
   request,
 }) => {
-  const data = validator.validate(await request.formData());
+  const data = await validator.validate(await request.formData());
   if (data.error) return validationError(data.error);
   const { firstName, lastName, email } = data.data;
 

--- a/apps/docs/app/routes/server-validation.mdx
+++ b/apps/docs/app/routes/server-validation.mdx
@@ -41,10 +41,7 @@ export const action: ActionFunction = async ({
 
   if (result.error) {
     // validationError comes from `remix-validated-form`
-    return validationError(
-      result.error,
-      result.submittedData
-    );
+    return validationError(result.error);
   }
 
   const { firstName, lastName, email } = result.data;

--- a/apps/docs/app/routes/server-validation.mdx
+++ b/apps/docs/app/routes/server-validation.mdx
@@ -35,17 +35,28 @@ We can re-use this validator in our action like this.
 export const action: ActionFunction = async ({
   request,
 }) => {
-  const data = await validator.validate(await request.formData());
-  if (data.error) return validationError(data.error);
-  const { firstName, lastName, email } = data.data;
+  const result = await validator.validate(
+    await request.formData()
+  );
 
+  if (result.error) {
+    // validationError comes from `remix-validated-form`
+    return validationError(
+      result.error,
+      result.submittedData
+    );
+  }
+
+  const { firstName, lastName, email } = result.data;
   // Do something with the data
 };
 ```
 
-If the `action` returns `validationError(data.error)`,
-the `ValidatedForm` will automatically pick up the error and display it.
-This is useful for cases where the user has javascript disabled.
+When we use the `validationError` to return our error,
+the `ValidatedForm` in our route component will automatically display the errors on the form fields.
+We pass the original data the user submitted as a second argument to `validationError`
+to specify how to repopulate the form if the user has JavaScript disabled.
+You can read more about this in the [API reference for `validationError`](/reference/validation-error).
 
 # Full implementation
 

--- a/apps/docs/app/routes/supporting-no-js.mdx
+++ b/apps/docs/app/routes/supporting-no-js.mdx
@@ -1,0 +1,47 @@
+---
+meta:
+  title: Supporting users without JS (Remix Validated Form)
+---
+
+# Supporting users without JS
+
+This library will support the no-JS use case as long as `remix` does.
+However, the way you go about doing this may vary depending on how important this is to you.
+
+## If supporting users without JS is important for you
+
+You should fall back to [native browser validation](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation)
+when JS is disabled. This is more work to maintain, but it's a better experience for users.
+
+In order to do this properly, you can pass `noValidate` to your `ValidatedForm` when JS is available.
+A helpful tool for doing that is [useHydrated from remix-utils](https://github.com/sergiodxa/remix-utils#usehydrated).
+
+```tsx
+const isHydrated = useHydrated();
+return <ValidatedForm noValidate={isHydrated} />;
+```
+
+This will allow `remix-validated-form` to take over validation when it can,
+but will fall back to native browser validation when it can't.
+
+## If users without JS are an edge-case
+
+The primary mechanism `remix-validated-form` has for supporting users without JS is
+the second argument of the `validationError` helper.
+This does come with some caveats, which you can read more about in the [validationError docs](/validation-error).
+
+Most of the time your code will look like this:
+
+```tsx
+const action: ActionFunction = async ({ request }) => {
+  const result = await validator.validate(
+    await request.formData()
+  );
+  if (result.error)
+    return validationError(
+      result.error,
+      result.submittedData
+    );
+  // do something with result.data
+};
+```

--- a/apps/docs/app/routes/username-exists.tsx
+++ b/apps/docs/app/routes/username-exists.tsx
@@ -1,0 +1,31 @@
+/**
+ * Endpoint used for asyncValidation example
+ */
+
+import { json, LoaderFunction } from "remix";
+import { zfd } from "zod-form-data";
+
+const schema = zfd.formData({
+  username: zfd.text(),
+});
+
+export const loader: LoaderFunction = async ({
+  request,
+}) => {
+  const params = new URL(request.url).searchParams;
+  const { username } = schema.parse(params);
+
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  if (
+    username.endsWith("123") ||
+    username.endsWith("234")
+  ) {
+    return json({ usernameTaken: false, suggestions: [] });
+  }
+
+  return json({
+    usernameTaken: true,
+    suggestions: [`${username}123`, `${username}234`],
+  });
+};

--- a/apps/docs/app/routes/validation-library-support.mdx
+++ b/apps/docs/app/routes/validation-library-support.mdx
@@ -26,11 +26,11 @@ type ValidateFieldResult = { error?: string };
 type Validator<DataType> = {
   validate: (
     unvalidatedData: unknown
-  ) => ValidationResult<DataType>;
+  ) => Promise<ValidationResult<DataType>>;
   validateField: (
     unvalidatedData: unknown,
     field: string
-  ) => ValidateFieldResult;
+  ) => Promise<ValidateFieldResult>;
 };
 ```
 
@@ -52,7 +52,7 @@ export const withYup = <Schema extends AnyObjectSchema>(
   // we return based on the provided schema
 ): Validator<InferType<Schema>> =>
   createValidator({
-    validate: (unvalidatedData) => {
+    validate: async (unvalidatedData) => {
       // Validate with yup and return the
       // validated & typed data or the error
 
@@ -67,7 +67,7 @@ export const withYup = <Schema extends AnyObjectSchema>(
           data: undefined,
         };
     },
-    validateField: (unvalidatedData, field) => {
+    validateField: async (unvalidatedData, field) => {
       // Validate the specific field with yup
 
       if (isValid) return { error: undefined };

--- a/apps/sample-app/app/routes/subjects/$id.edit.tsx
+++ b/apps/sample-app/app/routes/subjects/$id.edit.tsx
@@ -38,7 +38,9 @@ export const loader: LoaderFunction = async ({ params }) => {
 export const action: ActionFunction = async ({ request, params }) => {
   const { id } = z.object({ id: z.string() }).parse(params);
 
-  const fieldValues = subjectFormValidator.validate(await request.formData());
+  const fieldValues = await subjectFormValidator.validate(
+    await request.formData()
+  );
   if (fieldValues.error) return validationError(fieldValues.error);
 
   const { teacher, subjectDays, ...updatedSubject } = fieldValues.data;

--- a/apps/sample-app/app/routes/subjects/new.tsx
+++ b/apps/sample-app/app/routes/subjects/new.tsx
@@ -5,7 +5,9 @@ import { SubjectForm, subjectFormValidator } from "~/components/SubjectForm";
 import { db } from "~/services/db.server";
 
 export const action: ActionFunction = async ({ request }) => {
-  const fieldValues = subjectFormValidator.validate(await request.formData());
+  const fieldValues = await subjectFormValidator.validate(
+    await request.formData()
+  );
   if (fieldValues.error) return validationError(fieldValues.error);
 
   const { teacher, subjectDays, ...newSubject } = fieldValues.data;

--- a/apps/test-app/app/components/Input.tsx
+++ b/apps/test-app/app/components/Input.tsx
@@ -24,7 +24,7 @@ export const Input = forwardRef(
     }: InputProps,
     ref: React.ForwardedRef<HTMLInputElement>
   ) => {
-    const { getInputProps, error } = useField(name);
+    const { getInputProps, error, validationState } = useField(name);
     return (
       <div>
         <label htmlFor={name}>{label}</label>
@@ -38,7 +38,10 @@ export const Input = forwardRef(
             value,
           })}
         />
-        {error && !noErrors && <span style={{ color: "red" }}>{error}</span>}
+        {validationState === "validating" && <div>Validating...</div>}
+        {validationState === "invalid" && error && !noErrors && (
+          <span style={{ color: "red" }}>{error}</span>
+        )}
       </div>
     );
   }

--- a/apps/test-app/app/components/Input.tsx
+++ b/apps/test-app/app/components/Input.tsx
@@ -24,7 +24,7 @@ export const Input = forwardRef(
     }: InputProps,
     ref: React.ForwardedRef<HTMLInputElement>
   ) => {
-    const { getInputProps, error, validationState } = useField(name);
+    const { getInputProps, error } = useField(name);
     return (
       <div>
         <label htmlFor={name}>{label}</label>
@@ -38,10 +38,7 @@ export const Input = forwardRef(
             value,
           })}
         />
-        {validationState === "validating" && <div>Validating...</div>}
-        {validationState === "invalid" && error && !noErrors && (
-          <span style={{ color: "red" }}>{error}</span>
-        )}
+        {error && !noErrors && <span style={{ color: "red" }}>{error}</span>}
       </div>
     );
   }

--- a/apps/test-app/app/components/Input.tsx
+++ b/apps/test-app/app/components/Input.tsx
@@ -8,6 +8,7 @@ type InputProps = {
   value?: string;
   hideErrors?: boolean;
   "data-testid"?: string;
+  form?: string;
 };
 
 export const Input = forwardRef(
@@ -19,6 +20,7 @@ export const Input = forwardRef(
       value,
       hideErrors: noErrors,
       "data-testid": dataTestId,
+      form,
     }: InputProps,
     ref: React.ForwardedRef<HTMLInputElement>
   ) => {
@@ -29,6 +31,7 @@ export const Input = forwardRef(
         <input
           data-testid={dataTestId}
           {...getInputProps({
+            form,
             type,
             ref,
             id: name,

--- a/apps/test-app/app/components/SubmitButton.tsx
+++ b/apps/test-app/app/components/SubmitButton.tsx
@@ -1,17 +1,23 @@
-import { useIsSubmitting } from "remix-validated-form";
+import { useIsSubmitting, useIsValid } from "remix-validated-form";
 
 type Props = {
   label?: string;
   submittingLabel?: string;
+  disableWhenInvalid?: boolean;
 };
 
 export const SubmitButton = ({
   label = "Submit",
   submittingLabel = "Submitting...",
+  disableWhenInvalid,
 }: Props) => {
   const isSubmitting = useIsSubmitting();
+  const isValid = useIsValid();
   return (
-    <button type="submit" disabled={isSubmitting}>
+    <button
+      type="submit"
+      disabled={disableWhenInvalid ? isSubmitting || !isValid : isSubmitting}
+    >
       {isSubmitting ? submittingLabel : label}
     </button>
   );

--- a/apps/test-app/app/routes/checkboxes.tsx
+++ b/apps/test-app/app/routes/checkboxes.tsx
@@ -15,7 +15,7 @@ const validator = withZod(
 );
 
 export const action: ActionFunction = async ({ request }) => {
-  const result = validator.validate(await request.formData());
+  const result = await validator.validate(await request.formData());
   if (result.error) return validationError(result.error);
   const { likes } = result.data;
   const likesArray = Array.isArray(likes) ? likes : [likes];

--- a/apps/test-app/app/routes/custom-server-validation.tsx
+++ b/apps/test-app/app/routes/custom-server-validation.tsx
@@ -9,8 +9,11 @@ const schema = yup.object({});
 
 const validator = withYup(schema);
 
-export const action: ActionFunction = async ({ request }) => {
-  return validationError({ firstName: "Error" }, { firstName: "Bob" });
+export const action: ActionFunction = async () => {
+  return validationError(
+    { fieldErrors: { firstName: "Error" } },
+    { firstName: "Bob" }
+  );
 };
 
 export default function CustomServerValidation() {

--- a/apps/test-app/app/routes/file-input.tsx
+++ b/apps/test-app/app/routes/file-input.tsx
@@ -44,7 +44,7 @@ const testUploadHandler = async ({ name, stream }: any) => {
 };
 
 export const action: ActionFunction = async ({ request }) => {
-  const result = serverValidator.validate(
+  const result = await serverValidator.validate(
     await unstable_parseMultipartFormData(request, testUploadHandler)
   );
   if (result.error) return validationError(result.error);

--- a/apps/test-app/app/routes/submission.aftersubmit.tsx
+++ b/apps/test-app/app/routes/submission.aftersubmit.tsx
@@ -20,8 +20,9 @@ export const action: ActionFunction = async ({ request }) => {
   const testinput = formData.get("testinput");
   if (testinput === "fail")
     return validationError({
-      testinput: "Don't say that",
-      _submittedData: {} as any,
+      fieldErrors: {
+        testinput: "Don't say that",
+      },
     });
 
   return json({ message: "Submitted!" });

--- a/apps/test-app/app/routes/validation-async.tsx
+++ b/apps/test-app/app/routes/validation-async.tsx
@@ -31,7 +31,7 @@ const validator = withZod(
 
 export const action: ActionFunction = async ({ request }) => {
   const result = await validator.validate(await request.formData());
-  if (result.error) return validationError(result.error, result.submittedData);
+  if (result.error) return validationError(result.error);
   const { firstName, lastName } = result.data;
 
   return { message: `Submitted for ${firstName} ${lastName}!` };

--- a/apps/test-app/app/routes/validation-async.tsx
+++ b/apps/test-app/app/routes/validation-async.tsx
@@ -1,0 +1,51 @@
+import { withZod } from "@remix-validated-form/with-zod";
+import { ActionFunction, useActionData } from "remix";
+import { validationError, ValidatedForm } from "remix-validated-form";
+import { z } from "zod";
+import { zfd } from "zod-form-data";
+import { Input } from "~/components/Input";
+import { SubmitButton } from "~/components/SubmitButton";
+
+const pretendApi = (val1: any, val2: any): Promise<boolean> =>
+  new Promise((resolve) => setTimeout(() => resolve(val1 !== val2), 500));
+
+const validator = withZod(
+  zfd
+    .formData({
+      firstName: zfd.text(
+        z.string({
+          required_error: "First Name is a required field",
+        })
+      ),
+      lastName: zfd.text(
+        z.string({
+          required_error: "Last Name is a required field",
+        })
+      ),
+    })
+    .refine(async (data) => await pretendApi(data.firstName, data.lastName), {
+      message: "First Name and Last Name must be different",
+      path: ["lastName"],
+    })
+);
+
+export const action: ActionFunction = async ({ request }) => {
+  const result = await validator.validate(await request.formData());
+  if (result.error) return validationError(result.error, result.submittedData);
+  const { firstName, lastName } = result.data;
+
+  return { message: `Submitted for ${firstName} ${lastName}!` };
+};
+
+export default function FrontendValidation() {
+  const actionData = useActionData();
+  return (
+    <ValidatedForm validator={validator} method="post">
+      {actionData && <h1>{actionData.message}</h1>}
+      <Input name="firstName" label="First Name" />
+      <Input name="lastName" label="Last Name" />
+      <SubmitButton />
+      <button type="reset">Reset</button>
+    </ValidatedForm>
+  );
+}

--- a/apps/test-app/app/routes/validation-external.tsx
+++ b/apps/test-app/app/routes/validation-external.tsx
@@ -14,7 +14,10 @@ const validator = withZod(
 export default function FrontendValidation() {
   return (
     <>
-      <Input name="text1" type="text" label="Text 1" form="test-form" />
+      <label>
+        Text 1
+        <input name="text1" type="text" form="test-form" />
+      </label>
       <ValidatedForm validator={validator} method="post" id="test-form">
         <Input name="text2" type="text" label="Text 2" />
         <SubmitButton />

--- a/apps/test-app/app/routes/validation-external.tsx
+++ b/apps/test-app/app/routes/validation-external.tsx
@@ -1,0 +1,24 @@
+import { withZod } from "@remix-validated-form/with-zod";
+import { ValidatedForm } from "remix-validated-form";
+import { zfd } from "zod-form-data";
+import { Input } from "~/components/Input";
+import { SubmitButton } from "~/components/SubmitButton";
+
+const validator = withZod(
+  zfd.formData({
+    text1: zfd.text(),
+    text2: zfd.text(),
+  })
+);
+
+export default function FrontendValidation() {
+  return (
+    <>
+      <Input name="text1" type="text" label="Text 1" form="test-form" />
+      <ValidatedForm validator={validator} method="post" id="test-form">
+        <Input name="text2" type="text" label="Text 2" />
+        <SubmitButton />
+      </ValidatedForm>
+    </>
+  );
+}

--- a/apps/test-app/app/routes/validation-fetcher.tsx
+++ b/apps/test-app/app/routes/validation-fetcher.tsx
@@ -14,7 +14,7 @@ const schema = yup.object({
 const validator = withYup(schema);
 
 export const action: ActionFunction = async ({ request }) => {
-  const result = validator.validate(await request.formData());
+  const result = await validator.validate(await request.formData());
   if (result.error) return validationError(result.error);
   const { firstName, lastName } = result.data;
 

--- a/apps/test-app/app/routes/validation-isvalid.tsx
+++ b/apps/test-app/app/routes/validation-isvalid.tsx
@@ -1,0 +1,36 @@
+import { withZod } from "@remix-validated-form/with-zod";
+import { ActionFunction, useActionData } from "remix";
+import { validationError, ValidatedForm } from "remix-validated-form";
+import { z } from "zod";
+import { zfd } from "zod-form-data";
+import { Input } from "~/components/Input";
+import { SubmitButton } from "~/components/SubmitButton";
+
+const validator = withZod(
+  zfd.formData({
+    firstName: zfd.text(
+      z.string({
+        required_error: "First Name is a required field",
+      })
+    ),
+  })
+);
+
+export const action: ActionFunction = async ({ request }) => {
+  const result = await validator.validate(await request.formData());
+  if (result.error) return validationError(result.error, result.submittedData);
+  const { firstName } = result.data;
+
+  return { message: `Submitted for ${firstName}!` };
+};
+
+export default function FrontendValidation() {
+  const actionData = useActionData();
+  return (
+    <ValidatedForm validator={validator} method="post">
+      {actionData && <h1>{actionData.message}</h1>}
+      <Input name="firstName" label="First Name" />
+      <SubmitButton disableWhenInvalid />
+    </ValidatedForm>
+  );
+}

--- a/apps/test-app/app/routes/validation-isvalid.tsx
+++ b/apps/test-app/app/routes/validation-isvalid.tsx
@@ -18,7 +18,7 @@ const validator = withZod(
 
 export const action: ActionFunction = async ({ request }) => {
   const result = await validator.validate(await request.formData());
-  if (result.error) return validationError(result.error, result.submittedData);
+  if (result.error) return validationError(result.error);
   const { firstName } = result.data;
 
   return { message: `Submitted for ${firstName}!` };

--- a/apps/test-app/app/routes/validation-radio.tsx
+++ b/apps/test-app/app/routes/validation-radio.tsx
@@ -1,0 +1,37 @@
+import { withZod } from "@remix-validated-form/with-zod";
+import { ValidatedForm } from "remix-validated-form";
+import { z } from "zod";
+import { zfd } from "zod-form-data";
+import { Input } from "~/components/Input";
+import { SubmitButton } from "~/components/SubmitButton";
+
+const validator = withZod(
+  zfd.formData({
+    myRadio: z.literal("not valid ever"),
+    someText: zfd.text(),
+  })
+);
+
+export default function FrontendValidation() {
+  return (
+    <ValidatedForm
+      validator={validator}
+      method="post"
+      defaultValues={{
+        myRadio: "value2" as any,
+      }}
+    >
+      <Input name="myRadio" type="radio" label="Value 1" value="value1" />
+      <Input
+        name="myRadio"
+        type="radio"
+        label="Value 2"
+        value="value2"
+        data-testid="expected"
+      />
+      <Input name="myRadio" type="radio" label="Value 3" value="value3" />
+      <Input name="someText" type="text" label="Some text" />
+      <SubmitButton />
+    </ValidatedForm>
+  );
+}

--- a/apps/test-app/app/routes/validation.tsx
+++ b/apps/test-app/app/routes/validation.tsx
@@ -21,7 +21,7 @@ const schema = yup.object({
 const validator = withYup(schema);
 
 export const action: ActionFunction = async ({ request }) => {
-  const result = validator.validate(await request.formData());
+  const result = await validator.validate(await request.formData());
   if (result.error) return validationError(result.error);
   const { firstName, lastName } = result.data;
 

--- a/apps/test-app/app/routes/validation.tsx
+++ b/apps/test-app/app/routes/validation.tsx
@@ -1,28 +1,48 @@
-import { withYup } from "@remix-validated-form/with-yup";
+import { withZod } from "@remix-validated-form/with-zod";
 import { ActionFunction, useActionData } from "remix";
 import { validationError, ValidatedForm } from "remix-validated-form";
-import * as yup from "yup";
+import { z } from "zod";
+import { zfd } from "zod-form-data";
 import { Input } from "~/components/Input";
 import { SubmitButton } from "~/components/SubmitButton";
 
-const schema = yup.object({
-  firstName: yup.string().label("First Name").required(),
-  lastName: yup.string().label("Last Name").required(),
-  email: yup.string().label("Email").email().required(),
-  contacts: yup
-    .array(
-      yup.object({
-        name: yup.string().label("Name of a contact").required(),
+const validator = withZod(
+  zfd.formData({
+    firstName: zfd.text(
+      z.string({
+        required_error: "First Name is a required field",
       })
-    )
-    .required(),
-});
-
-const validator = withYup(schema);
+    ),
+    lastName: zfd.text(
+      z.string({
+        required_error: "Last Name is a required field",
+      })
+    ),
+    email: zfd.text(
+      z
+        .string({
+          required_error: "Email is a required field",
+        })
+        .email({
+          message: "Email must be a valid email",
+        })
+    ),
+    contacts: z.array(
+      z.object({
+        name: zfd.text(
+          z.string({
+            required_error: "Name of a contact is a required field",
+          })
+        ),
+      })
+    ),
+    likesPizza: zfd.checkbox(),
+  })
+);
 
 export const action: ActionFunction = async ({ request }) => {
   const result = await validator.validate(await request.formData());
-  if (result.error) return validationError(result.error);
+  if (result.error) return validationError(result.error, result.submittedData);
   const { firstName, lastName } = result.data;
 
   return { message: `Submitted for ${firstName} ${lastName}!` };
@@ -37,6 +57,7 @@ export default function FrontendValidation() {
       <Input name="lastName" label="Last Name" />
       <Input name="email" label="Email" />
       <Input name="contacts[0].name" label="Name of a contact" />
+      <Input name="likesPizza" type="checkbox" label="Likes pizza" />
       <SubmitButton />
       <button type="reset">Reset</button>
     </ValidatedForm>

--- a/apps/test-app/app/routes/zod-form-data.tsx
+++ b/apps/test-app/app/routes/zod-form-data.tsx
@@ -46,7 +46,7 @@ const paramSchema = zfd.formData({
 });
 
 export const action: ActionFunction = async ({ request }) => {
-  const result = validator.validate(await request.formData());
+  const result = await validator.validate(await request.formData());
   if (result.error) return validationError(result.error);
   const { firstName, lastName } = result.data;
 

--- a/apps/test-app/cypress/integration/async-validation.ts
+++ b/apps/test-app/cypress/integration/async-validation.ts
@@ -12,6 +12,10 @@ describe("Async Validation", () => {
 
     cy.findByLabelText("Last Name").type("John");
     cy.findByText("First Name and Last Name must be different").should("exist");
+
+    cy.findByText("Submit").click();
+    cy.findByText("Submitting...").should("exist");
+    cy.findByText("Submit").should("be.enabled");
     cy.findByLabelText("Last Name").clear().type("Doe");
 
     cy.findByText("Submit").click();

--- a/apps/test-app/cypress/integration/async-validation.ts
+++ b/apps/test-app/cypress/integration/async-validation.ts
@@ -1,0 +1,22 @@
+describe("Async Validation", () => {
+  it("should support async validation", () => {
+    cy.visit("/validation-async");
+
+    cy.findByLabelText("First Name").focus().blur();
+    cy.findByText("First Name is a required field").should("exist");
+    cy.findByLabelText("First Name").type("John");
+    cy.findByText("First Name is a required field").should("not.exist");
+
+    cy.findByLabelText("Last Name").focus().blur();
+    cy.findByText("Validating...").should("not.exist");
+    cy.findByText("Last Name is a required field").should("exist");
+
+    cy.findByLabelText("Last Name").type("John");
+    cy.findByText("Validating...").should("exist");
+    cy.findByText("First Name and Last Name must be different").should("exist");
+    cy.findByLabelText("Last Name").clear().type("Doe");
+
+    cy.findByText("Submit").click();
+    cy.findByText("Submitted for John Doe!").should("exist");
+  });
+});

--- a/apps/test-app/cypress/integration/async-validation.ts
+++ b/apps/test-app/cypress/integration/async-validation.ts
@@ -8,11 +8,9 @@ describe("Async Validation", () => {
     cy.findByText("First Name is a required field").should("not.exist");
 
     cy.findByLabelText("Last Name").focus().blur();
-    cy.findByText("Validating...").should("not.exist");
     cy.findByText("Last Name is a required field").should("exist");
 
     cy.findByLabelText("Last Name").type("John");
-    cy.findByText("Validating...").should("exist");
     cy.findByText("First Name and Last Name must be different").should("exist");
     cy.findByLabelText("Last Name").clear().type("Doe");
 

--- a/apps/test-app/cypress/integration/validation.ts
+++ b/apps/test-app/cypress/integration/validation.ts
@@ -70,6 +70,17 @@ describe("Validation", () => {
     cy.findByText("Submitted for John Doe!").should("exist");
   });
 
+  it("should reset isValid to true when errors resolved", () => {
+    cy.visit("/validation-isvalid");
+
+    cy.findByText("Submit").click();
+
+    cy.findByText("First Name is a required field").should("exist");
+    cy.findByText("Submit").should("be.disabled");
+    cy.findByLabelText("First Name").should("be.focused").type("John");
+    cy.findByText("Submit").should("be.enabled");
+  });
+
   it("should focus the first invalid field", () => {
     cy.visit("/validation");
 

--- a/apps/test-app/cypress/integration/validation.ts
+++ b/apps/test-app/cypress/integration/validation.ts
@@ -82,6 +82,18 @@ describe("Validation", () => {
     cy.findByLabelText("First Name").should("be.focused");
   });
 
+  it("should focus the selected radio if that is the first invalid field", () => {
+    cy.visit("/validation-radio");
+    cy.findByText("Submit").click();
+    cy.findByTestId("expected").should("be.focused");
+  });
+
+  it("should focus the first invalid field even if it's outside the form", () => {
+    cy.visit("/validation-external");
+    cy.findByText("Submit").click();
+    cy.findByLabelText("Text 1").should("be.focused");
+  });
+
   it("should not focus the first invalid field if disableFocusOnError is true", () => {
     cy.visit("/validation-nofocus");
 
@@ -122,11 +134,12 @@ describe("Validation", () => {
     cy.findByText("Submitted for John Doe!").should("exist");
   });
 
-  it("should not lose field values when showing validation errors without JS", () => {
+  it("should support repopulating field values when showing validation errors without JS", () => {
     cy.visitWithoutJs("/validation");
 
     cy.findByLabelText("First Name").type("John");
     cy.findByLabelText("Last Name").type("Doe");
+    cy.findByLabelText("Likes pizza").click();
     cy.findByText("Submit").click();
 
     cy.findByText("First Name is a required field").should("not.exist");
@@ -136,6 +149,7 @@ describe("Validation", () => {
 
     cy.findByLabelText("First Name").should("have.value", "John");
     cy.findByLabelText("Last Name").should("have.value", "Doe");
+    cy.findByLabelText("Likes pizza").should("be.checked");
 
     cy.findByLabelText("Email").type("an.email@example.com");
     cy.findByLabelText("Name of a contact").type("Someone else");
@@ -144,7 +158,7 @@ describe("Validation", () => {
     cy.findByText("Submitted for John Doe!").should("exist");
   });
 
-  it("should not lose field values when showing custom validation if done properly", () => {
+  it("should support repopulating field values when showing custom validation", () => {
     cy.visitWithoutJs("/custom-server-validation");
 
     cy.findByText("Submit").click();

--- a/packages/remix-validated-form/src/ValidatedForm.tsx
+++ b/packages/remix-validated-form/src/ValidatedForm.tsx
@@ -246,8 +246,7 @@ export function ValidatedForm<DataType>({
       action,
       defaultValues: defaultsToUse,
       isSubmitting: isSubmitting ?? false,
-      validationState:
-        Object.keys(fieldErrors).length === 0 ? "valid" : "invalid",
+      isValid: Object.keys(fieldErrors).length === 0,
       touchedFields,
       setFieldTouched: (fieldName: string, touched: boolean) =>
         setTouchedFields((prev) => ({
@@ -274,11 +273,13 @@ export function ValidatedForm<DataType>({
               [fieldName]: error,
             };
           });
+          return error;
         } else {
           setFieldErrors((prev) => {
             if (!(fieldName in prev)) return prev;
             return omit(prev, fieldName);
           });
+          return null;
         }
       },
       registerReceiveFocus: (fieldName, handler) => {

--- a/packages/remix-validated-form/src/ValidatedForm.tsx
+++ b/packages/remix-validated-form/src/ValidatedForm.tsx
@@ -315,14 +315,18 @@ export function ValidatedForm<DataType>({
         HTMLButtonElement | HTMLInputElement
       >("button,input[type=submit]");
 
-      if (submitButton && submitButton.type === "submit") {
+      if (
+        submitButton &&
+        submitButton.form === form &&
+        submitButton.type === "submit"
+      ) {
         clickedButtonRef.current = submitButton;
       }
     }
 
-    form.addEventListener("click", handleClick);
+    window.addEventListener("click", handleClick);
     return () => {
-      form && form.removeEventListener("click", handleClick);
+      window.removeEventListener("click", handleClick);
     };
   }, []);
 

--- a/packages/remix-validated-form/src/ValidatedForm.tsx
+++ b/packages/remix-validated-form/src/ValidatedForm.tsx
@@ -225,6 +225,7 @@ export function ValidatedForm<DataType>({
     backendError?.fieldErrors
   );
   const isSubmitting = useIsSubmitting(action, subaction, fetcher);
+  const [isValidating, setIsValidating] = useState(false);
   const defaultsToUse = useDefaultValues(
     backendError?.repopulateFields,
     defaultValues
@@ -234,6 +235,7 @@ export function ValidatedForm<DataType>({
   const submit = useSubmit();
   const formRef = useRef<HTMLFormElement>(null);
   useSubmitComplete(isSubmitting, () => {
+    setIsValidating(false);
     if (!backendError && resetAfterSubmit) {
       formRef.current?.reset();
     }
@@ -245,7 +247,7 @@ export function ValidatedForm<DataType>({
       fieldErrors,
       action,
       defaultValues: defaultsToUse,
-      isSubmitting: isSubmitting ?? false,
+      isSubmitting: isValidating || isSubmitting,
       isValid: Object.keys(fieldErrors).length === 0,
       touchedFields,
       setFieldTouched: (fieldName: string, touched: boolean) =>
@@ -294,6 +296,7 @@ export function ValidatedForm<DataType>({
       fieldErrors,
       action,
       defaultsToUse,
+      isValidating,
       isSubmitting,
       touchedFields,
       hasBeenSubmitted,
@@ -339,10 +342,12 @@ export function ValidatedForm<DataType>({
       onSubmit={async (e) => {
         e.preventDefault();
         setHasBeenSubmitted(true);
+        setIsValidating(true);
         const result = await validator.validate(
           getDataFromForm(e.currentTarget)
         );
         if (result.error) {
+          setIsValidating(false);
           setFieldErrors(result.error.fieldErrors);
           if (!disableFocusOnError) {
             focusFirstInvalidInput(

--- a/packages/remix-validated-form/src/hooks.ts
+++ b/packages/remix-validated-form/src/hooks.ts
@@ -126,3 +126,8 @@ export const useFormContext = () => useContext(FormContext);
  * is aware of what form it's in and when _that_ form is being submitted.
  */
 export const useIsSubmitting = () => useFormContext().isSubmitting;
+
+/**
+ * Returns the current validation state of the form.
+ */
+export const useValidationState = () => useFormContext().validationState;

--- a/packages/remix-validated-form/src/hooks.ts
+++ b/packages/remix-validated-form/src/hooks.ts
@@ -8,6 +8,15 @@ import {
   ValidationBehaviorOptions,
 } from "./internal/getInputProps";
 
+const useInternalFormContext = (hookName: string) => {
+  const context = useContext(FormContext);
+  if (!context)
+    throw new Error(
+      `${hookName} must be used within a ValidatedForm or ValidatedForm.Provider component`
+    );
+  return context;
+};
+
 export type FieldProps = {
   /**
    * The validation error message if there is one.
@@ -66,7 +75,7 @@ export const useField = (
     touchedFields,
     setFieldTouched,
     hasBeenSubmitted,
-  } = useContext(FormContext);
+  } = useInternalFormContext("useField");
 
   const isTouched = !!touchedFields[name];
   const { handleReceiveFocus } = options ?? {};
@@ -116,18 +125,20 @@ export const useField = (
 
 /**
  * Provides access to the entire form context.
- * This is not usually necessary, but can be useful for advanced use cases.
+ * Must be used within a ValidatedForm or ValidatedForm.Provider component.
  */
-export const useFormContext = () => useContext(FormContext);
+export const useFormContext = () => useInternalFormContext("useFormContext");
 
 /**
  * Returns whether or not the parent form is currently being submitted.
  * This is different from remix's `useTransition().submission` in that it
  * is aware of what form it's in and when _that_ form is being submitted.
  */
-export const useIsSubmitting = () => useFormContext().isSubmitting;
+export const useIsSubmitting = () =>
+  useInternalFormContext("useIsSubmitting").isSubmitting;
 
 /**
  * Returns the current validation state of the form.
  */
-export const useValidationState = () => useFormContext().validationState;
+export const useValidationState = () =>
+  useInternalFormContext("useValidationState").validationState;

--- a/packages/remix-validated-form/src/internal/formContext.ts
+++ b/packages/remix-validated-form/src/internal/formContext.ts
@@ -13,7 +13,7 @@ export type FormContextValue = {
   /**
    * Validate the specified field.
    */
-  validateField: (fieldName: string) => Promise<void>;
+  validateField: (fieldName: string) => Promise<string | null>;
   /**
    * The `action` prop of the form.
    */
@@ -29,9 +29,9 @@ export type FormContextValue = {
    */
   hasBeenSubmitted: boolean;
   /**
-   * The current validation state of the form
+   * Whether or not the form is valid.
    */
-  validationState: "idle" | "validating" | "valid" | "invalid";
+  isValid: boolean;
   /**
    * The default values of the form.
    */

--- a/packages/remix-validated-form/src/internal/formContext.ts
+++ b/packages/remix-validated-form/src/internal/formContext.ts
@@ -13,7 +13,7 @@ export type FormContextValue = {
   /**
    * Validate the specified field.
    */
-  validateField: (fieldName: string) => void;
+  validateField: (fieldName: string) => Promise<void>;
   /**
    * The `action` prop of the form.
    */
@@ -29,10 +29,9 @@ export type FormContextValue = {
    */
   hasBeenSubmitted: boolean;
   /**
-   * Whether or not the form is valid.
-   * This is a shortcut for `Object.keys(fieldErrors).length === 0`.
+   * The current validation state of the form
    */
-  isValid: boolean;
+  validationState: "idle" | "validating" | "valid" | "invalid";
   /**
    * The default values of the form.
    */
@@ -55,10 +54,10 @@ export type FormContextValue = {
 export const FormContext = createContext<FormContextValue>({
   fieldErrors: {},
   clearError: () => {},
-  validateField: () => {},
+  validateField: async () => await new Promise((res) => res()),
   isSubmitting: false,
   hasBeenSubmitted: false,
-  isValid: true,
+  validationState: "idle",
   registerReceiveFocus: () => () => {},
   touchedFields: {},
   setFieldTouched: () => {},

--- a/packages/remix-validated-form/src/internal/formContext.ts
+++ b/packages/remix-validated-form/src/internal/formContext.ts
@@ -51,14 +51,4 @@ export type FormContextValue = {
   setFieldTouched: (fieldName: string, touched: boolean) => void;
 };
 
-export const FormContext = createContext<FormContextValue>({
-  fieldErrors: {},
-  clearError: () => {},
-  validateField: async () => await new Promise((res) => res()),
-  isSubmitting: false,
-  hasBeenSubmitted: false,
-  validationState: "idle",
-  registerReceiveFocus: () => () => {},
-  touchedFields: {},
-  setFieldTouched: () => {},
-});
+export const FormContext = createContext<FormContextValue | null>(null);

--- a/packages/remix-validated-form/src/server.ts
+++ b/packages/remix-validated-form/src/server.ts
@@ -9,7 +9,7 @@ import {
  * When you return this from your action, `ValidatedForm` on the frontend will automatically
  * display the errors on the correct fields on the correct form.
  *
- * _Recommended_: You can also provide a second argument to `validationError`
+ * You can also provide a second argument to `validationError`
  * to specify how to repopulate the form when JS is disabled.
  *
  * @example

--- a/packages/remix-validated-form/src/server.ts
+++ b/packages/remix-validated-form/src/server.ts
@@ -1,26 +1,33 @@
 import { json } from "@remix-run/server-runtime";
-import { FieldErrors } from "./validation/types";
+import {
+  ValidatorError,
+  ValidationErrorResponseData,
+} from "./validation/types";
 
 /**
  * Takes the errors from a `Validator` and returns a `Response`.
- * The `ValidatedForm` on the frontend will automatically display the errors
- * if this is returned from the action.
+ * When you return this from your action, `ValidatedForm` on the frontend will automatically
+ * display the errors on the correct fields on the correct form.
+ *
+ * _Recommended_: You can also provide a second argument to `validationError`
+ * to specify how to repopulate the form when JS is disabled.
+ *
+ * @example
+ * ```ts
+ * const result = validator.validate(await request.formData());
+ * if (result.error) return validationError(result.error, result.submittedData);
+ * ```
  */
-export const validationError = (
-  errors: FieldErrors,
-  submittedData?: unknown
-) => {
-  if (submittedData) {
-    return json(
-      {
-        fieldErrors: {
-          ...errors,
-          _submittedData: submittedData,
-        },
-      },
-      { status: 422 }
-    );
-  }
-
-  return json({ fieldErrors: errors }, { status: 422 });
-};
+export function validationError(
+  error: ValidatorError,
+  repopulateFields?: unknown
+): Response {
+  return json<ValidationErrorResponseData>(
+    {
+      fieldErrors: error.fieldErrors,
+      subaction: error.subaction,
+      repopulateFields,
+    },
+    { status: 422 }
+  );
+}

--- a/packages/remix-validated-form/src/types.ts
+++ b/packages/remix-validated-form/src/types.ts
@@ -1,0 +1,1 @@
+export type ValidationState = "idle" | "validating" | "valid" | "invalid";

--- a/packages/remix-validated-form/src/types.ts
+++ b/packages/remix-validated-form/src/types.ts
@@ -1,1 +1,0 @@
-export type ValidationState = "idle" | "validating" | "valid" | "invalid";

--- a/packages/remix-validated-form/src/validation/createValidator.ts
+++ b/packages/remix-validated-form/src/validation/createValidator.ts
@@ -39,7 +39,7 @@ export function createValidator<T>(
         submittedData: data,
       };
     },
-    validateField: async (data: GenericObject | FormData, field: string) =>
-      await validator.validateField(preprocessFormData(data), field),
+    validateField: (data: GenericObject | FormData, field: string) =>
+      validator.validateField(preprocessFormData(data), field),
   };
 }

--- a/packages/remix-validated-form/src/validation/createValidator.ts
+++ b/packages/remix-validated-form/src/validation/createValidator.ts
@@ -16,9 +16,9 @@ const preprocessFormData = (data: GenericObject | FormData): GenericObject => {
  */
 export function createValidator<T>(validator: Validator<T>): Validator<T> {
   return {
-    validate: (value: GenericObject | FormData) => {
+    validate: async (value: GenericObject | FormData) => {
       const data = preprocessFormData(value);
-      const result = validator.validate(data);
+      const result = await validator.validate(data);
       if (result.error) {
         // Ideally, we should probably be returning a nested object like
         // { fieldErrors: {}, submittedData: {} }
@@ -28,7 +28,7 @@ export function createValidator<T>(validator: Validator<T>): Validator<T> {
       }
       return result;
     },
-    validateField: (data: GenericObject | FormData, field: string) =>
-      validator.validateField(preprocessFormData(data), field),
+    validateField: async (data: GenericObject | FormData, field: string) =>
+      await validator.validateField(preprocessFormData(data), field),
   };
 }

--- a/packages/remix-validated-form/src/validation/types.ts
+++ b/packages/remix-validated-form/src/validation/types.ts
@@ -22,11 +22,13 @@ export type ValidateFieldResult = { error?: string };
  * A `Validator` can be passed to the `validator` prop of a `ValidatedForm`.
  */
 export type Validator<DataType> = {
-  validate: (unvalidatedData: GenericObject) => ValidationResult<DataType>;
+  validate: (
+    unvalidatedData: GenericObject
+  ) => Promise<ValidationResult<DataType>>;
   validateField: (
     unvalidatedData: GenericObject,
     field: string
-  ) => ValidateFieldResult;
+  ) => Promise<ValidateFieldResult>;
 };
 
 export type ValidatorData<T extends Validator<any>> = T extends Validator<

--- a/packages/remix-validated-form/src/validation/types.ts
+++ b/packages/remix-validated-form/src/validation/types.ts
@@ -51,11 +51,13 @@ export type Validator<DataType> = {
 export type Valid<DataType> = { data: DataType; error: undefined };
 export type Invalid = { error: FieldErrors; data: undefined };
 export type CreateValidatorArg<DataType> = {
-  validate: (unvalidatedData: GenericObject) => Valid<DataType> | Invalid;
+  validate: (
+    unvalidatedData: GenericObject
+  ) => Promise<Valid<DataType> | Invalid>;
   validateField: (
     unvalidatedData: GenericObject,
     field: string
-  ) => ValidateFieldResult;
+  ) => Promise<ValidateFieldResult>;
 };
 
 export type ValidatorData<T extends Validator<any>> = T extends Validator<

--- a/packages/remix-validated-form/src/validation/types.ts
+++ b/packages/remix-validated-form/src/validation/types.ts
@@ -2,16 +2,33 @@ export type FieldErrors = Record<string, string>;
 
 export type TouchedFields = Record<string, boolean>;
 
-export type FieldErrorsWithData = FieldErrors & { _submittedData: any };
-
 export type GenericObject = { [key: string]: any };
+
+export type ValidatorError = {
+  subaction?: string;
+  fieldErrors: FieldErrors;
+};
+
+export type ValidationErrorResponseData = {
+  subaction?: string;
+  fieldErrors: FieldErrors;
+  repopulateFields?: unknown;
+};
+
+export type BaseResult = { submittedData: GenericObject };
+export type ErrorResult = BaseResult & {
+  error: ValidatorError;
+  data: undefined;
+};
+export type SuccessResult<DataType> = BaseResult & {
+  data: DataType;
+  error: undefined;
+};
 
 /**
  * The result when validating a form.
  */
-export type ValidationResult<DataType> =
-  | { data: DataType; error: undefined }
-  | { error: FieldErrors; data: undefined };
+export type ValidationResult<DataType> = SuccessResult<DataType> | ErrorResult;
 
 /**
  * The result when validating an individual field in a form.
@@ -29,6 +46,16 @@ export type Validator<DataType> = {
     unvalidatedData: GenericObject,
     field: string
   ) => Promise<ValidateFieldResult>;
+};
+
+export type Valid<DataType> = { data: DataType; error: undefined };
+export type Invalid = { error: FieldErrors; data: undefined };
+export type CreateValidatorArg<DataType> = {
+  validate: (unvalidatedData: GenericObject) => Valid<DataType> | Invalid;
+  validateField: (
+    unvalidatedData: GenericObject,
+    field: string
+  ) => ValidateFieldResult;
 };
 
 export type ValidatorData<T extends Validator<any>> = T extends Validator<

--- a/packages/validation-tests/tests/validation.test.ts
+++ b/packages/validation-tests/tests/validation.test.ts
@@ -196,7 +196,7 @@ describe("Validation", () => {
         });
       });
 
-      it("should return the subactino in the ValidatorError if there is one", () => {
+      it("should return the subaction in the ValidatorError if there is one", async () => {
         const person = {
           lastName: "Doe",
           age: 20,
@@ -208,7 +208,7 @@ describe("Validation", () => {
           pets: [{ animal: "dog", name: "Fido" }],
           subaction: "updatePerson",
         };
-        expect(validator.validate(person)).toEqual({
+        expect(await validator.validate(person)).toEqual({
           error: {
             fieldErrors: {
               firstName: anyString,

--- a/packages/validation-tests/tests/validation.test.ts
+++ b/packages/validation-tests/tests/validation.test.ts
@@ -96,6 +96,7 @@ describe("Validation", () => {
         expect(await validator.validate(person)).toEqual({
           data: person,
           error: undefined,
+          submittedData: person,
         });
       });
 
@@ -104,15 +105,18 @@ describe("Validation", () => {
         expect(await validator.validate(obj)).toEqual({
           data: undefined,
           error: {
-            firstName: anyString,
-            lastName: anyString,
-            age: anyString,
-            "address.city": anyString,
-            "address.country": anyString,
-            "address.streetAddress": anyString,
-            "pets[0].name": anyString,
-            _submittedData: obj,
+            fieldErrors: {
+              firstName: anyString,
+              lastName: anyString,
+              age: anyString,
+              "address.city": anyString,
+              "address.country": anyString,
+              "address.streetAddress": anyString,
+              "pets[0].name": anyString,
+            },
+            subaction: undefined,
           },
+          submittedData: obj,
         });
       });
 
@@ -140,6 +144,7 @@ describe("Validation", () => {
             pets: [{ animal: "dog", name: "Fido" }],
           },
           error: undefined,
+          submittedData: objectFromPathEntries(Object.entries(data)),
         });
       });
 
@@ -154,10 +159,13 @@ describe("Validation", () => {
         expect(await validator.validate(formData)).toEqual({
           data: undefined,
           error: {
-            "address.city": anyString,
-            "pets[0].name": anyString,
-            _submittedData: objectFromPathEntries([...formData.entries()]),
+            fieldErrors: {
+              "address.city": anyString,
+              "pets[0].name": anyString,
+            },
+            subaction: undefined,
           },
+          submittedData: objectFromPathEntries([...formData.entries()]),
         });
       });
 
@@ -183,6 +191,32 @@ describe("Validation", () => {
             pets: [{ animal: "dog", name: "Fido" }],
           },
           error: undefined,
+          subaction: undefined,
+          submittedData: objectFromPathEntries([...formData.entries()]),
+        });
+      });
+
+      it("should return the subactino in the ValidatorError if there is one", () => {
+        const person = {
+          lastName: "Doe",
+          age: 20,
+          address: {
+            streetAddress: "123 Main St",
+            city: "Anytown",
+            country: "USA",
+          },
+          pets: [{ animal: "dog", name: "Fido" }],
+          subaction: "updatePerson",
+        };
+        expect(validator.validate(person)).toEqual({
+          error: {
+            fieldErrors: {
+              firstName: anyString,
+            },
+            subaction: "updatePerson",
+          },
+          data: undefined,
+          submittedData: person,
         });
       });
     });

--- a/packages/validation-tests/tests/validation.test.ts
+++ b/packages/validation-tests/tests/validation.test.ts
@@ -81,7 +81,7 @@ const validationTestCases: ValidationTestCase[] = [
 describe("Validation", () => {
   describe.each(validationTestCases)("Adapter for $name", ({ validator }) => {
     describe("validate", () => {
-      it("should return the data when valid", () => {
+      it("should return the data when valid", async () => {
         const person: Person = {
           firstName: "John",
           lastName: "Doe",
@@ -93,15 +93,15 @@ describe("Validation", () => {
           },
           pets: [{ animal: "dog", name: "Fido" }],
         };
-        expect(validator.validate(person)).toEqual({
+        expect(await validator.validate(person)).toEqual({
           data: person,
           error: undefined,
         });
       });
 
-      it("should return field errors when invalid", () => {
+      it("should return field errors when invalid", async () => {
         const obj = { age: "hi!", pets: [{ animal: "dog" }] };
-        expect(validator.validate(obj)).toEqual({
+        expect(await validator.validate(obj)).toEqual({
           data: undefined,
           error: {
             firstName: anyString,
@@ -116,7 +116,7 @@ describe("Validation", () => {
         });
       });
 
-      it("should unflatten data when validating", () => {
+      it("should unflatten data when validating", async () => {
         const data = {
           firstName: "John",
           lastName: "Doe",
@@ -127,7 +127,7 @@ describe("Validation", () => {
           "pets[0].animal": "dog",
           "pets[0].name": "Fido",
         };
-        expect(validator.validate(data)).toEqual({
+        expect(await validator.validate(data)).toEqual({
           data: {
             firstName: "John",
             lastName: "Doe",
@@ -143,7 +143,7 @@ describe("Validation", () => {
         });
       });
 
-      it("should accept FormData directly and return errors", () => {
+      it("should accept FormData directly and return errors", async () => {
         const formData = new TestFormData();
         formData.set("firstName", "John");
         formData.set("lastName", "Doe");
@@ -151,7 +151,7 @@ describe("Validation", () => {
         formData.set("address.country", "USA");
         formData.set("pets[0].animal", "dog");
 
-        expect(validator.validate(formData)).toEqual({
+        expect(await validator.validate(formData)).toEqual({
           data: undefined,
           error: {
             "address.city": anyString,
@@ -161,7 +161,7 @@ describe("Validation", () => {
         });
       });
 
-      it("should accept FormData directly and return valid data", () => {
+      it("should accept FormData directly and return valid data", async () => {
         const formData = new TestFormData();
         formData.set("firstName", "John");
         formData.set("lastName", "Doe");
@@ -171,7 +171,7 @@ describe("Validation", () => {
         formData.set("pets[0].animal", "dog");
         formData.set("pets[0].name", "Fido");
 
-        expect(validator.validate(formData)).toEqual({
+        expect(await validator.validate(formData)).toEqual({
           data: {
             firstName: "John",
             lastName: "Doe",
@@ -188,16 +188,16 @@ describe("Validation", () => {
     });
 
     describe("validateField", () => {
-      it("should not return an error if field is valid", () => {
+      it("should not return an error if field is valid", async () => {
         const person = {
           firstName: "John",
           lastName: {}, // invalid, but we should only be validating firstName
         };
-        expect(validator.validateField(person, "firstName")).toEqual({
+        expect(await validator.validateField(person, "firstName")).toEqual({
           error: undefined,
         });
       });
-      it("should not return an error if a nested field is valid", () => {
+      it("should not return an error if a nested field is valid", async () => {
         const person = {
           firstName: "John",
           lastName: {}, // invalid, but we should only be validating firstName
@@ -209,25 +209,29 @@ describe("Validation", () => {
           pets: [{ animal: "dog", name: "Fido" }],
         };
         expect(
-          validator.validateField(person, "address.streetAddress")
+          await validator.validateField(person, "address.streetAddress")
         ).toEqual({
           error: undefined,
         });
-        expect(validator.validateField(person, "address.city")).toEqual({
+        expect(await validator.validateField(person, "address.city")).toEqual({
           error: undefined,
         });
-        expect(validator.validateField(person, "address.country")).toEqual({
+        expect(
+          await validator.validateField(person, "address.country")
+        ).toEqual({
           error: undefined,
         });
-        expect(validator.validateField(person, "pets[0].animal")).toEqual({
-          error: undefined,
-        });
-        expect(validator.validateField(person, "pets[0].name")).toEqual({
+        expect(await validator.validateField(person, "pets[0].animal")).toEqual(
+          {
+            error: undefined,
+          }
+        );
+        expect(await validator.validateField(person, "pets[0].name")).toEqual({
           error: undefined,
         });
       });
 
-      it("should return an error if field is invalid", () => {
+      it("should return an error if field is invalid", async () => {
         const person = {
           firstName: "John",
           lastName: {},
@@ -236,12 +240,12 @@ describe("Validation", () => {
             city: 1234,
           },
         };
-        expect(validator.validateField(person, "lastName")).toEqual({
+        expect(await validator.validateField(person, "lastName")).toEqual({
           error: anyString,
         });
       });
 
-      it("should return an error if a nested field is invalid", () => {
+      it("should return an error if a nested field is invalid", async () => {
         const person = {
           firstName: "John",
           lastName: {},
@@ -251,10 +255,12 @@ describe("Validation", () => {
           },
           pets: [{ animal: "dog" }],
         };
-        expect(validator.validateField(person, "address.country")).toEqual({
+        expect(
+          await validator.validateField(person, "address.country")
+        ).toEqual({
           error: anyString,
         });
-        expect(validator.validateField(person, "pets[0].name")).toEqual({
+        expect(await validator.validateField(person, "pets[0].name")).toEqual({
           error: anyString,
         });
       });

--- a/packages/validation-tests/tests/with-zod.test.ts
+++ b/packages/validation-tests/tests/with-zod.test.ts
@@ -23,11 +23,14 @@ describe("withZod", () => {
     expect(await withZod(schema).validate(obj)).toEqual({
       data: undefined,
       error: {
-        type: anyString,
-        bar: anyString,
-        foo: anyString,
-        _submittedData: obj,
+        fieldErrors: {
+          type: anyString,
+          bar: anyString,
+          foo: anyString,
+        },
+        subaction: undefined,
       },
+      submittedData: obj,
     });
   });
 
@@ -45,10 +48,13 @@ describe("withZod", () => {
     expect(await validator.validate(obj)).toEqual({
       data: undefined,
       error: {
-        field1: anyString,
-        field2: anyString,
-        _submittedData: obj,
+        fieldErrors: {
+          field1: anyString,
+          field2: anyString,
+        },
+        subaction: undefined,
       },
+      submittedData: obj,
     });
     expect(await validator.validateField(obj, "field1")).toEqual({
       error: anyString,

--- a/packages/validation-tests/tests/with-zod.test.ts
+++ b/packages/validation-tests/tests/with-zod.test.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { anyString } from "./util";
 
 describe("withZod", () => {
-  it("returns coherent errors for complex schemas", () => {
+  it("returns coherent errors for complex schemas", async () => {
     const schema = z.union([
       z.object({
         type: z.literal("foo"),
@@ -20,7 +20,7 @@ describe("withZod", () => {
       foo: 123,
     };
 
-    expect(withZod(schema).validate(obj)).toEqual({
+    expect(await withZod(schema).validate(obj)).toEqual({
       data: undefined,
       error: {
         type: anyString,
@@ -31,7 +31,7 @@ describe("withZod", () => {
     });
   });
 
-  it("returns errors for fields that are unions", () => {
+  it("returns errors for fields that are unions", async () => {
     const schema = z.object({
       field1: z.union([z.literal("foo"), z.literal("bar")]),
       field2: z.union([z.literal("foo"), z.literal("bar")]),
@@ -42,7 +42,7 @@ describe("withZod", () => {
     };
 
     const validator = withZod(schema);
-    expect(validator.validate(obj)).toEqual({
+    expect(await validator.validate(obj)).toEqual({
       data: undefined,
       error: {
         field1: anyString,
@@ -50,10 +50,10 @@ describe("withZod", () => {
         _submittedData: obj,
       },
     });
-    expect(validator.validateField(obj, "field1")).toEqual({
+    expect(await validator.validateField(obj, "field1")).toEqual({
       error: anyString,
     });
-    expect(validator.validateField(obj, "field2")).toEqual({
+    expect(await validator.validateField(obj, "field2")).toEqual({
       error: anyString,
     });
   });

--- a/packages/with-yup/src/index.ts
+++ b/packages/with-yup/src/index.ts
@@ -17,9 +17,9 @@ export const withYup = <Schema extends AnyObjectSchema>(
   validationSchema: Schema
 ): Validator<InferType<Schema>> => {
   return createValidator({
-    validate: (data) => {
+    validate: async (data) => {
       try {
-        const validated = validationSchema.validateSync(data, {
+        const validated = await validationSchema.validate(data, {
           abortEarly: false,
         });
         return { data: validated, error: undefined };
@@ -30,9 +30,9 @@ export const withYup = <Schema extends AnyObjectSchema>(
         };
       }
     },
-    validateField: (data, field) => {
+    validateField: async (data, field) => {
       try {
-        validationSchema.validateSyncAt(field, data);
+        await validationSchema.validateAt(field, data);
         return {};
       } catch (err) {
         return { error: (err as ValidationError).message };

--- a/packages/with-zod/src/index.ts
+++ b/packages/with-zod/src/index.ts
@@ -27,8 +27,8 @@ export function withZod<T, U>(
   zodSchema: z.Schema<T, U, unknown>
 ): Validator<T> {
   return createValidator({
-    validate: (value) => {
-      const result = zodSchema.safeParse(value);
+    validate: async (value) => {
+      const result = await zodSchema.safeParseAsync(value);
       if (result.success) return { data: result.data, error: undefined };
 
       const fieldErrors: FieldErrors = {};
@@ -38,8 +38,8 @@ export function withZod<T, U>(
       });
       return { error: fieldErrors, data: undefined };
     },
-    validateField: (data, field) => {
-      const result = zodSchema.safeParse(data);
+    validateField: async (data, field) => {
+      const result = await zodSchema.safeParseAsync(data);
       if (result.success) return { error: undefined };
       return {
         error: getIssuesForError(result.error).find((issue) => {


### PR DESCRIPTION
Will add release notes here:

---

# Remix Validated Form 4

### Async validation 🎉 

`zod` and `yup` schemas with async validations are now supported. Read more about this [here](https://remix-validated-form.io/async-validation).

### Support auto-focusing inputs outside of the `form` element

If you have any inputs portaled outside the actual `form` element (but still a child of the `ValidatedForm`) it will now be able to receive focus automatically if it has a validation error. Before, when submitting the form, it would only focus errored inputs within the form itself.

### useIsValid hook

A handy hook to get access to the `isValid` value from context without tapping directly into `useFormContext`.

### Bug fixes

* Fixed a bug where `isValid` wasn't correctly becoming `true` when the form errors were cleared. (#52)

# Breaking changes & migration guide

## Validators are now async

This is a small small migration that should only impact your server code for the most part.
```diff
- const result = validator.validate(await request.formData())
+ const result = await validator.validate(await request.formData())
```

## Form hooks can no longer be used outside of a `ValidatedForm`

Previously, all the hooks (`useField`, `useIsSubmitting`, etc), could be used outside of a `ValidatedForm` but wouldn't actually do anything. I originally did this because I thought I might want to use my inputs in a native `form` or plain remix `Form`. In practice, it rarely makes sense to use anything but `ValidatedForm` and having the hooks not throw an error outside a form has caused a lot of confusion.

## Forms are no longer automatically repopulated in the no-JS case

If supporting users without JS is not important to you, this is not really breaking at all. If it is, I recommend reading the docs on this topic [here](https://remix-validated-form.io).

To keep the behavior exactly how it is, this is the change:

```diff
- if (result.error) return validationError(result.error);
+ if (result.error) return validationError(result.error, result.submittedData);
```

**Why make this change?**:
* There are a few caveats to repopulating form data that I've outlined in the [validationError docs](https://www.remix-validated-form.io/reference/validation-error).
* I don't think this library should automatically return data without the developer being aware of what's going on. If your form involves sensitive data, you should have full control over what's being returned from your API.