### PR TITLE
chore: allow installation in React 18 projects

### DIFF
--- a/packages/remix-validated-form/package.json
+++ b/packages/remix-validated-form/package.json
@@ -35,7 +35,7 @@
   "peerDependencies": {
     "@remix-run/react": "1.x",
     "@remix-run/server-runtime": "1.x",
-    "react": "^17.0.2"
+    "react": "^17.0.2 || ^18.0.0"
   },
   "devDependencies": {
     "@remix-run/react": "^1.2.1",


### PR DESCRIPTION
fix #86 

I only updated the peer dependencies version range. I don't have `yarn` setup locally and was running into issues with the project setup, so this is unfortunately all I was able to contribute with the time I had available. Hopefully this helps a bit.

I chose the version range of `^17.0.2 || ^18.0.0` to continue to support React 17  to maintain the package's semver compatibility.