### PR TITLE
Enable sourceMaps

### DIFF
--- a/packages/vite-config/index.js
+++ b/packages/vite-config/index.js
@@ -16,6 +16,7 @@ exports.makeConfig = ({ lib, external, dir }) =>
         formats: ["cjs", "es", "umd"],
       },
       rollupOptions: { external },
+      sourcemap: true,
     },
     plugins: [
       dts({


### PR DESCRIPTION
This greatly aids debugging the library, since without it stack traces originating in the library are minified. Additionally, bundlers will simply ignore them if the library consumer doesn't want to publish their source, so there's no drawback to including them.