### PR TITLE
Fix `file-input` cypress test

### DIFF
--- a/apps/test-app/app/routes/file-input.tsx
+++ b/apps/test-app/app/routes/file-input.tsx
@@ -1,9 +1,12 @@
+import {
+  unstable_composeUploadHandlers,
+  unstable_createMemoryUploadHandler,
+} from "@remix-run/server-runtime";
 import { withZod } from "@remix-validated-form/with-zod";
 import {
   ActionFunction,
   useActionData,
   unstable_parseMultipartFormData,
-  UploadHandler,
 } from "remix";
 import { validationError, ValidatedForm } from "remix-validated-form";
 import { z } from "zod";
@@ -35,13 +38,13 @@ const serverValidator = withZod(
   )
 );
 
-const testUploadHandler: UploadHandler = async ({ name }) => {
+const testUploadHandler = unstable_composeUploadHandlers(async ({ name }) => {
   if (name !== "myFile") {
     return;
   }
 
   return "testFile";
-};
+}, unstable_createMemoryUploadHandler());
 
 export const action: ActionFunction = async ({ request }) => {
   const result = await serverValidator.validate(


### PR DESCRIPTION
This is a follow-up PR for fixing the `file-input` Cypess test caused by the https://github.com/airjp73/remix-validated-form/pull/142