### PR TITLE
Add pre-validation onSubmit callback

### DIFF
--- a/packages/remix-validated-form/src/ValidatedForm.tsx
+++ b/packages/remix-validated-form/src/ValidatedForm.tsx
@@ -50,6 +50,13 @@ export type FormProps<DataType> = {
     data: DataType,
     event: React.FormEvent<HTMLFormElement>
   ) => void | Promise<void>;
+    /**
+   * A callback that gets called when the form is submitted
+   * before onSubmit validations have been run.
+   */
+  onSubmitBeforeValidation?: (
+    event: React.FormEvent<HTMLFormElement>
+  ) => void | Promise<void>;
   /**
    * Allows you to provide a `fetcher` from remix's `useFetcher` hook.
    * The form will use the fetcher for loading states, action data, etc
@@ -201,6 +208,7 @@ type HTMLFormSubmitter = HTMLButtonElement | HTMLInputElement;
 export function ValidatedForm<DataType>({
   validator,
   onSubmit,
+  onSubmitBeforeValidation,
   children,
   fetcher,
   action,
@@ -303,6 +311,7 @@ export function ValidatedForm<DataType>({
     nativeEvent: HTMLSubmitEvent["nativeEvent"]
   ) => {
     startSubmit();
+    await onSubmitBeforeValidation?.(e);
     const result = await validator.validate(getDataFromForm(e.currentTarget));
     if (result.error) {
       endSubmit();


### PR DESCRIPTION
I added an optional onSubmitBeforeValidation callback that runs before the validation in onSubmit.  This allows non-standard inputs like [tiptap](https://tiptap.dev/) and [editor.js](https://editorjs.io/) to serialize their data to a hidden form field which will be validated by ValidatedForm's onSubmit handler and submitted to the Remix action handler.

## Example
```
const schemaTipTap = z.object({
  hidden_editor_value: zfd.text()
    .refine(data => {
      return !!stripWhiteSpace(stripHtml(data))
    }, { message: "Required", path: ["hidden_editor_value"] })
})
const validator = withZod(schemaTipTap)
```

```
<ValidatedForm>
  method="post"
  validator={validator}
  onSubmitBeforeValidation={(e) => {
    const el = e.currentTarget.elements.namedItem("hidden_editor_value") as HTMLInputElement
    if (el) {
      el.value = editorRef.current?.getHTML() ?? ""
    }
    // The HTML-serialized contents of the editor will now be validated by ValidatedForm's onSubmit handler and submitted to the Remix action handler
  }}
</ValidatedForm>
```