### PR TITLE
Add missing license field to zod-form-data

### DIFF
--- a/packages/zod-form-data/package.json
+++ b/packages/zod-form-data/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/zod-form-data.umd.js",
   "module": "./dist/zod-form-data.es.js",
   "types": "./dist/types/index.d.ts",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/airjp73/remix-validated-form"


### PR DESCRIPTION
The license field is missing in package.json for `zod-form-data`.

This means that the correct license is not displayed in npmjs, as well as affecting license scanning dependency tools