### PR TITLE
fix: input and output types

### DIFF
--- a/packages/zod-form-data/src/helpers.ts
+++ b/packages/zod-form-data/src/helpers.ts
@@ -115,8 +115,12 @@ export const repeatableOfType = <T extends ZodTypeAny>(
 const entries = z.array(z.tuple([z.string(), z.any()]));
 
 type FormDataType = {
-  <T extends z.ZodRawShape>(shape: T): ZodEffects<ZodObject<T>>;
-  <T extends z.ZodTypeAny>(schema: T): ZodEffects<T>;
+  <T extends z.ZodRawShape>(shape: T): ZodEffects<
+    ZodObject<T>,
+    z.output<ZodObject<T>>,
+    FormData
+  >;
+  <T extends z.ZodTypeAny>(schema: T): ZodEffects<T, z.output<T>, FormData>;
 };
 
 const safeParseJson = (jsonString: string) => {

--- a/packages/zod-form-data/src/helpers.ts
+++ b/packages/zod-form-data/src/helpers.ts
@@ -114,16 +114,22 @@ export const repeatableOfType = <T extends ZodTypeAny>(
 
 const entries = z.array(z.tuple([z.string(), z.any()]));
 
+type FormDataLikeInput = {
+  [Symbol.iterator](): IterableIterator<[string, FormDataEntryValue]>;
+  entries(): IterableIterator<[string, FormDataEntryValue]>;
+};
+
 type FormDataType = {
   <T extends z.ZodRawShape>(shape: T): ZodEffects<
     ZodObject<T>,
     z.output<ZodObject<T>>,
-    {
-      [Symbol.iterator](): IterableIterator<[string, FormDataEntryValue]>;
-      entries(): IterableIterator<[string, FormDataEntryValue]>;
-    }
+    FormDataLikeInput
   >;
-  <T extends z.ZodTypeAny>(schema: T): ZodEffects<T, z.output<T>, FormData>;
+  <T extends z.ZodTypeAny>(schema: T): ZodEffects<
+    T,
+    z.output<T>,
+    FormDataLikeInput
+  >;
 };
 
 const safeParseJson = (jsonString: string) => {

--- a/packages/zod-form-data/src/helpers.ts
+++ b/packages/zod-form-data/src/helpers.ts
@@ -118,7 +118,10 @@ type FormDataType = {
   <T extends z.ZodRawShape>(shape: T): ZodEffects<
     ZodObject<T>,
     z.output<ZodObject<T>>,
-    FormData
+    {
+      [Symbol.iterator](): IterableIterator<[string, FormDataEntryValue]>;
+      entries(): IterableIterator<[string, FormDataEntryValue]>;
+    }
   >;
   <T extends z.ZodTypeAny>(schema: T): ZodEffects<T, z.output<T>, FormData>;
 };


### PR DESCRIPTION
```ts
zfd.formData({
  name: zfd.text()
})._input
```
is now of type `FormData` instead of `{ name: string }`.

```ts
const formDataSchema = zfd.formData({
  name: zfd.text()
})

const form = formDataSchema.parse(formData)
```
`form` is still typed as `{ name: string }` here.

I need this type to be correct so input types are inferred accurately for a form data integration I'm working on for [tRPC](https://github.com/trpc/trpc/compare/trpc:09634d5...trpc:bea7865#diff-ac3ed79d27fe031890ac3a59f5d04d89d6848ce5dae67f6594d9aff23721e279R95).