### PR TITLE
add `FormData` as an input type on schemas

### DIFF
--- a/packages/zod-form-data/src/helpers.ts
+++ b/packages/zod-form-data/src/helpers.ts
@@ -123,12 +123,12 @@ type FormDataType = {
   <T extends z.ZodRawShape>(shape: T): ZodEffects<
     ZodObject<T>,
     z.output<ZodObject<T>>,
-    FormDataLikeInput
+    FormData | FormDataLikeInput
   >;
   <T extends z.ZodTypeAny>(schema: T): ZodEffects<
     T,
     z.output<T>,
-    FormDataLikeInput
+    FormData | FormDataLikeInput
   >;
 };
 


### PR DESCRIPTION
Is this kosher to how you're using the library?

I'm looking to do an integration with [tRPC](https://trpc.io) and I don't wanna do `as any`s when submitting formData :)

Otherwise, I might be missing some easy coercion between a raw `FormData` and a `FormDataLike`-object that matches my schema