### PR TITLE
Replace useTransition with useNavigation

### DIFF
--- a/packages/remix-validated-form/src/internal/hooks.ts
+++ b/packages/remix-validated-form/src/internal/hooks.ts
@@ -107,7 +107,7 @@ export const useHasActiveFormSubmit = ({
   const navigation = useNavigation();
   const hasActiveSubmission = fetcher
     ? fetcher.state === "submitting"
-    : !!navigation.submission;
+    : !!navigation.formData;
   return hasActiveSubmission;
 };
 

--- a/packages/remix-validated-form/src/internal/hooks.ts
+++ b/packages/remix-validated-form/src/internal/hooks.ts
@@ -1,4 +1,4 @@
-import { useActionData, useMatches, useTransition } from "@remix-run/react";
+import { useActionData, useMatches, useNavigation } from "@remix-run/react";
 import { useCallback, useContext } from "react";
 import { getPath } from "set-get";
 import invariant from "tiny-invariant";
@@ -104,10 +104,10 @@ export const useDefaultValuesForForm = (
 export const useHasActiveFormSubmit = ({
   fetcher,
 }: InternalFormContextValue): boolean => {
-  const transition = useTransition();
+  const navigation = useNavigation();
   const hasActiveSubmission = fetcher
     ? fetcher.state === "submitting"
-    : !!transition.submission;
+    : !!navigation.submission;
   return hasActiveSubmission;
 };
 


### PR DESCRIPTION
`useTransition` is deprecated and will be removed in Remix v2 per the browser warning.  Per the remix documentation, `useNavigation` removes the `submission` property, so this needs to be accounted for.  Is it sufficient to check `navigation.formData`?

This PR resolves https://github.com/airjp73/remix-validated-form/issues/261.