### PR TITLE
Add explicit `undefined`s to `MinimalInputProps`

### DIFF
--- a/packages/remix-validated-form/src/internal/getInputProps.ts
+++ b/packages/remix-validated-form/src/internal/getInputProps.ts
@@ -25,12 +25,12 @@ type HandledProps = "name" | "defaultValue" | "defaultChecked";
 type Callbacks = "onChange" | "onBlur";
 
 type MinimalInputProps = {
-  onChange?: (...args: any[]) => void;
-  onBlur?: (...args: any[]) => void;
+  onChange?: ((...args: any[]) => void) | undefined;
+  onBlur?: ((...args: any[]) => void) | undefined;
   defaultValue?: any;
-  defaultChecked?: boolean;
-  name?: string;
-  type?: string;
+  defaultChecked?: boolean | undefined;
+  name?: string | undefined;
+  type?: string | undefined;
 };
 
 export type GetInputProps = <T extends MinimalInputProps>(


### PR DESCRIPTION
With the compiler option `exactOptionalPropertyTypes` is set to `true` (e.g. when using [@tsconfig/strictest](https://www.npmjs.com/package/@tsconfig/strictest) base config), the type of `getInputProps` can't be inferred correctly.

For example, using the [`Checkbox` component from the docs app](https://github.com/airjp73/remix-validated-form/blob/e6f1855b83b35f0ad27fe19b807855474cf39294/apps/docs/app/components/Checkbox.tsx):

```
Checkbox.tsx:21:49 - error TS2345: Argument of type '{ type: string; value: string | undefined; }' is not assignable to parameter of type 'Omit<MinimalInputProps, HandledProps | Callbacks> & Partial<Pick<MinimalInputProps, Callbacks>>'.
  Object literal may only specify known properties, and 'value' does not exist in type 'Omit<MinimalInputProps, HandledProps | Callbacks> & Partial<Pick<MinimalInputProps, Callbacks>>'.

21           {...getInputProps({ type: "checkbox", value })}
                                                   ~~~~~


Found 1 error in Checkbox.tsx:21
```

The generic type argument for `getInputProps` is inferred as `MinimalInputProps`, because the actual props of the `input` element don't extend that type. Explicitly providing the type argument makes that clear:

```
Checkbox.tsx:21:29 - error TS2344: Type 'DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>' does not satisfy the constraint 'MinimalInputProps'.
  Types of property 'onChange' are incompatible.
    Type 'ChangeEventHandler<HTMLInputElement> | undefined' is not assignable to type '(...args: any[]) => void'.
      Type 'undefined' is not assignable to type '(...args: any[]) => void'.

21           {...getInputProps<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>>({ type: "checkbox", value })}
                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in Checkbox.tsx:21
```

Adding an explicit `| undefined` to all the prop types in `MinimalInputProps` (to match the [definition in @types/react](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L2271-L2309)) fixes the issue.
