### PR TITLE
use `DeepPartial` for acceptable `DataType` into `ValidatedForm`

### DIFF
--- a/packages/remix-validated-form/src/ValidatedForm.tsx
+++ b/packages/remix-validated-form/src/ValidatedForm.tsx
@@ -43,6 +43,12 @@ import {
 } from "./internal/util";
 import { FieldErrors, Validator } from "./validation/types";
 
+type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>;
+    }
+  : T;
+
 type SubactionData<
   DataType,
   Subaction extends string | undefined
@@ -83,7 +89,7 @@ export type FormProps<DataType, Subaction extends string | undefined> = {
    * Accepts an object of default values for the form
    * that will automatically be propagated to the form fields via `useField`.
    */
-  defaultValues?: Partial<DataForSubaction<DataType, Subaction>>;
+  defaultValues?: DeepPartial<DataForSubaction<DataType, Subaction>>;
   /**
    * A ref to the form element.
    */
@@ -221,7 +227,10 @@ type HTMLFormSubmitter = HTMLButtonElement | HTMLInputElement;
 /**
  * The primary form component of `remix-validated-form`.
  */
-export function ValidatedForm<DataType, Subaction extends string | undefined>({
+export function ValidatedForm<
+  DataType extends { [fieldName: string]: any },
+  Subaction extends string | undefined
+>({
   validator,
   onSubmit,
   children,


### PR DESCRIPTION
closes #313 

* Adds a `DeepPartial` type
* Uses `DeepPartial` for default types, allowing users to pre-set set a subset of deeply nested fields (useful for [arrays and nested](https://www.remix-validated-form.io/arrays-and-nested) types)

```tsx
// example todo validator
const validator = withZod(
  z.array(
    z.object({
      title: z.string()
      dueDate: z.string()
    })
  )
);

...

<ValidatedForm validator={validator} defaultValues={[{ title: 'my todo' }]}> // Without a `DeepPartial` this causes a type error
   // ...
</ValidatedForm>
```

* Updates `DataType` to extend `{ [fieldName: string]: any }` for `ValidatedForm`
  * My understanding is that is a requirement anyway, but without explicitly specifying the constraint `DeepPartial` will cause a type error on the `InternalFormContextValue`. This is because `DeepPartial<DataType>` will unpack as `DataType | { P in keyof DataType]?: DeepPartial<DataType[P]> | undefined`. Since `DataType` could be anything, it isn't assignable to the expected `{ [fieldName: string]: any; }` for `defaultValuesProp`