### PR TITLE
chore(deps): pin upper remix version to 2

### DIFF
--- a/packages/remix-validated-form/package.json
+++ b/packages/remix-validated-form/package.json
@@ -33,9 +33,9 @@
     "validation"
   ],
   "peerDependencies": {
-    "@remix-run/node": ">= 1.16.1",
-    "@remix-run/react": ">= 1.15.0",
-    "@remix-run/server-runtime": ">= 1.16.1",
+    "@remix-run/node": ">= 1.16.1 <3.0.0",
+    "@remix-run/react": ">= 1.15.0 <3.0.0",
+    "@remix-run/server-runtime": ">= 1.16.1 <3.0.0",
     "react": "^17.0.2 || ^18.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I wonder how continuing supporting a diverging API will work in the future but for now the library seems to support both v1 and v2.