### PR TITLE
Update package.json for zod to 3.22.3 or greater

### DIFF
--- a/apps/bug-repro/package.json
+++ b/apps/bug-repro/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^18.1.0",
     "remix-validated-form": "*",
     "yup": "*",
-    "zod": "*"
+    "zod": "~3.20.0"
   },
   "devDependencies": {
     "@remix-run/dev": "^1.16.1",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -31,7 +31,7 @@
     "react-dom": "^18.1.0",
     "rehype-highlight": "^5.0.1",
     "remix-validated-form": "*",
-    "zod": "^3.11.6",
+    "zod": "~3.20.0",
     "zod-form-data": "*"
   },
   "devDependencies": {

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -26,7 +26,7 @@
     "react-dom": "^18.1.0",
     "remix-validated-form": "*",
     "yup": "^1.0.0",
-    "zod": "^3.11.6",
+    "zod": "~3.20.0",
     "zod-form-data": "*"
   },
   "devDependencies": {

--- a/packages/with-zod/package.json
+++ b/packages/with-zod/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "remix-validated-form": "^4.x || ^5.x",
-    "zod": "^3.11.x"
+    "zod": ">= 3.11.0"
   },
   "devDependencies": {
     "@remix-validated-form/with-yup": "*",
@@ -28,6 +28,6 @@
     "tsconfig": "*",
     "tsup-config": "*",
     "typescript": "^4.8.4",
-    "zod": "^3.11.6"
+    "zod": "~3.20.0"
   }
 }

--- a/packages/zod-form-data/package.json
+++ b/packages/zod-form-data/package.json
@@ -23,7 +23,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "zod": "^3.11.x"
+    "zod": "^3.22.3"
   },
   "devDependencies": {
     "set-get": "*",

--- a/packages/zod-form-data/package.json
+++ b/packages/zod-form-data/package.json
@@ -23,13 +23,13 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "zod": "^3.22.3"
+    "zod": ">= 3.11.0"
   },
   "devDependencies": {
     "set-get": "*",
     "tsconfig": "*",
     "tsup-config": "*",
     "typescript": "^4.8.4",
-    "zod": "^3.11.6"
+    "zod": "~3.20.0"
   }
 }

--- a/packages/zod-form-data/src/zod-form-data.test.ts
+++ b/packages/zod-form-data/src/zod-form-data.test.ts
@@ -173,6 +173,7 @@ describe("zod helpers", () => {
             minimum: 0,
             type: "number",
             inclusive: false,
+            exact: false,
             message: "Number must be greater than 0",
             path: [1],
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11013,10 +11013,10 @@ yup@^1.0.0:
     toposort "^2.0.2"
     type-fest "^2.19.0"
 
-zod@*, zod@^3.11.6:
-  version "3.19.1"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.19.1.tgz#112f074a97b50bfc4772d4ad1576814bd8ac4473"
-  integrity sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==
+zod@~3.20.0:
+  version "3.20.6"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.20.6.tgz#2f2f08ff81291d47d99e86140fedb4e0db08361a"
+  integrity sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA==
 
 zustand@^4.3.0:
   version "4.3.2"


### PR DESCRIPTION
https://github.com/colinhacks/zod/releases/tag/v3.22.3

Fixes #2609

The current regex used for email validation contains "catastrophic backtracking", specifically ([A-Z0-9_+-]+\.?)*. This gets evaluated inefficiently by JS, resulting in an exponential increase in execution time for failed matches.

This can be replicated easily - here's execution time against ^([A-Z0-9_+-]+\.?)*[A-Z0-9_+-]@([A-Z0-9][A-Z0-9\-]*\.)+[A-Z]{2,}$